### PR TITLE
Creating ask-sdk-model-runtime package

### DIFF
--- a/ask-sdk-model-runtime/CHANGELOG.rst
+++ b/ask-sdk-model-runtime/CHANGELOG.rst
@@ -1,0 +1,8 @@
+=========
+CHANGELOG
+=========
+
+1.0
+-------
+
+* Initial release of alexa sdk model runtime.

--- a/ask-sdk-model-runtime/MANIFEST.in
+++ b/ask-sdk-model-runtime/MANIFEST.in
@@ -1,0 +1,6 @@
+include README.rst
+include CHANGELOG.rst
+include LICENSE
+include requirements.txt
+recursive-exclude tests *
+recursive-include ask_sdk_model_runtime py.typed

--- a/ask-sdk-model-runtime/README.rst
+++ b/ask-sdk-model-runtime/README.rst
@@ -1,0 +1,52 @@
+====================================================
+ASK SDK Model Runtime - Base components of ASK SDK
+====================================================
+
+ask-sdk-model-runtime is the common models package by
+the Software Development Kit (SDK) team for Python that
+provides common implementations like Serializer, ApiClient
+BaseServiceClient, Authentication Configuration etc.
+that is used by the SDK models.
+
+Quick Start
+-----------
+
+Installation
+~~~~~~~~~~~~~~~
+Assuming that you have Python and ``virtualenv`` installed, you can
+install the package and it's dependencies from PyPi
+as follows:
+
+.. code-block:: sh
+
+    $ virtualenv venv
+    $ . venv/bin/activate
+    $ pip install ask-sdk-model-runtime
+
+
+You can also install the whole standard package locally by following these steps:
+
+.. code-block:: sh
+
+    $ git clone https://github.com/alexa/alexa-apis-for-python.git
+    $ cd ask_sdk_model_runtime
+    $ virtualenv venv
+    ...
+    $ . venv/bin/activate
+    $ python setup.py install
+
+
+Usage and Getting Started
+-------------------------
+
+Getting started guides, SDK Features, API references, samples etc. can
+be found at `Read The Docs <https://alexa-skills-kit-python-sdk.readthedocs.io/en/latest/>`_
+
+
+Got Feedback?
+-------------
+
+- We would like to hear about your bugs, feature requests, questions or quick feedback.
+  Please search for the `existing issues <https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues>`_ before opening a new one. It would also be helpful
+  if you follow the templates for issue and pull request creation. Please follow the `contributing guidelines <https://github.com/alexa/alexa-skills-kit-sdk-for-python/blob/master/CONTRIBUTING.md>`_!
+- Request and vote for `Alexa features <https://alexa.uservoice.com/forums/906892-alexa-skills-developer-voice-and-vote>`_!

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/__init__.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/__init__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+from __future__ import absolute_import
+
+from .api_client_message import ApiClientMessage
+from .api_client_request import ApiClientRequest
+from .api_client_response import ApiClientResponse
+from .api_client import DefaultApiClient, ApiClient
+from .api_configuration import ApiConfiguration
+from .api_response import ApiResponse
+from .authentication_configuration import AuthenticationConfiguration
+from .base_service_client import BaseServiceClient
+from .serializer import DefaultSerializer, Serializer
+from .exceptions import (
+    ServiceException, SerializationException, ApiClientException)
+from .service_client_response import ServiceClientResponse

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/__version__.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/__version__.py
@@ -20,7 +20,7 @@ __description__ = ('The ASK SDK Model Runtime package provides common provides '
                    'common implementations like Serializer, ApiClient, '
                    'Authentication Configuration etc that is used by the SDK '
                    'models.')
-__url__ = 'https://github.com/alexa/alexa-skills-kit-sdk-for-python'
+__url__ = 'https://github.com/alexa/alexa-apis-for-python'
 __version__ = '1.0.0'
 __author__ = 'Alexa Skills Kit'
 __author_email__ = 'ask-sdk-dynamic@amazon.com'

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/__version__.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/__version__.py
@@ -1,0 +1,29 @@
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+
+__pip_package_name__ = 'ask-sdk-model-runtime'
+__description__ = ('The ASK SDK Model Runtime package provides common provides '
+                   'common implementations like Serializer, ApiClient, '
+                   'Authentication Configuration etc that is used by the SDK '
+                   'models.')
+__url__ = 'https://github.com/alexa/alexa-skills-kit-sdk-for-python'
+__version__ = '1.0.0'
+__author__ = 'Alexa Skills Kit'
+__author_email__ = 'ask-sdk-dynamic@amazon.com'
+__license__ = 'Apache 2.0'
+__keywords__ = ['ASK SDK Model Runtime', 'Alexa Skills Kit', 'Alexa', 'Model', 'Runtime']
+__install_requires__ = ["requests", "python_dateutil"]

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/api_client.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/api_client.py
@@ -161,7 +161,7 @@ class DefaultApiClient(ApiClient):
             for key, values in six.iteritems(headers_dict):
                 for value in values.split(","):
                     value = value.strip()
-                    if value is not None and value is not '':
+                    if value is not None and value != '':
                         headers_list.append((key, value.strip()))
         return headers_list
 

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/api_client.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/api_client.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+import typing
+import requests
+import six
+import json
+
+from abc import ABCMeta, abstractmethod
+from urllib3.util import parse_url
+
+from .api_client_response import ApiClientResponse
+
+from .exceptions import ApiClientException
+
+if typing.TYPE_CHECKING:
+    from typing import Callable, Dict, List, Tuple
+    from ask_sdk_model_runtime import ApiClientRequest, ApiClientResponse
+
+
+class ApiClient(object):
+    """Represents a basic contract for API request invocation."""
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def invoke(self, request):
+        # type: (ApiClientRequest) -> ApiClientResponse
+        """Dispatches a request to an API endpoint described in the request.
+        The ApiClient is expected to resolve in the case an API returns
+        a non-200 HTTP status code. The responsibility of translating a
+        particular response code to an error lies with the caller.
+        :param request: Request to dispatch to the ApiClient
+        :type request: ApiClientRequest
+        :return: Response from the client call
+        :rtype: ApiClientResponse
+        """
+        pass
+
+
+class DefaultApiClient(ApiClient):
+    """Default ApiClient implementation of
+    :py:class:`ask_sdk_model_runtime.api_client.ApiClient` using the
+    `requests` library.
+    """
+
+    def invoke(self, request):
+        # type: (ApiClientRequest) -> ApiClientResponse
+        """Dispatches a request to an API endpoint described in the
+        request.
+        Resolves the method from input request object, converts the
+        list of header tuples to the required format (dict) for the
+        `requests` lib call and invokes the method with corresponding
+        parameters on `requests` library. The response from the call is
+        wrapped under the `ApiClientResponse` object and the
+        responsibility of translating a response code and response/
+        error lies with the caller.
+        :param request: Request to dispatch to the ApiClient
+        :type request: ApiClientRequest
+        :return: Response from the client call
+        :rtype: ApiClientResponse
+        :raises: :py:class:`ask_sdk_model_runtime.exceptions.ApiClientException`
+        """
+        try:
+            http_method = self._resolve_method(request)
+            http_headers = self._convert_list_tuples_to_dict(
+                headers_list=request.headers)
+
+            parsed_url = parse_url(request.url)
+            if parsed_url.scheme is None or parsed_url.scheme != "https":
+                raise ApiClientException(
+                    "Requests against non-HTTPS endpoints are not allowed.")
+
+            if request.body:
+                body_content_type = http_headers.get("Content-type", None)
+                if (body_content_type is not None and
+                        "json" in body_content_type):
+                    raw_data = json.dumps(request.body)
+                else:
+                    raw_data = request.body
+            else:
+                raw_data = None
+
+            http_response = http_method(
+                url=request.url, headers=http_headers, data=raw_data)
+
+            return ApiClientResponse(
+                headers=self._convert_dict_to_list_tuples(
+                    http_response.headers),
+                status_code=http_response.status_code,
+                body=http_response.text)
+        except Exception as e:
+            raise ApiClientException(
+                "Error executing the request: {}".format(str(e)))
+
+    def _resolve_method(self, request):
+        # type: (ApiClientRequest) -> Callable
+        """Resolve the method from request object to `requests` http
+        call.
+        :param request: Request to dispatch to the ApiClient
+        :type request: ApiClientRequest
+        :return: The HTTP method that maps to the request call.
+        :rtype: Callable
+        :raises :py:class:`ask_sdk_model_runtime.exceptions.ApiClientException`
+            if invalid http request method is being called
+        """
+        try:
+            return getattr(requests, request.method.lower())
+        except AttributeError:
+            raise ApiClientException(
+                "Invalid request method: {}".format(request.method))
+
+    def _convert_list_tuples_to_dict(self, headers_list):
+        # type: (List[Tuple[str, str]]) -> Dict[str, str]
+        """Convert list of tuples from headers of request object to
+        dictionary format.
+        :param headers_list: List of tuples made up of two element
+            strings from `ApiClientRequest` headers variable
+        :type headers_list: List[Tuple[str, str]]
+        :return: Dictionary of headers in keys as strings and values
+            as comma separated strings
+        :rtype: Dict[str, str]
+        """
+        headers_dict = {}  # type: Dict
+        if headers_list is not None:
+            for header_tuple in headers_list:
+                key, value = header_tuple[0], header_tuple[1]
+                if key in headers_dict:
+                    headers_dict[key] = "{}, {}".format(
+                        headers_dict[key], value)
+                else:
+                    headers_dict[header_tuple[0]] = value
+        return headers_dict
+
+    def _convert_dict_to_list_tuples(self, headers_dict):
+        # type: (Dict[str, str]) -> List[Tuple[str, str]]
+        """Convert headers dict to list of string tuples format for
+        `ApiClientResponse` headers variable.
+        :param headers_dict: Dictionary of headers in keys as strings
+            and values as comma separated strings
+        :type headers_dict: Dict[str, str]
+        :return: List of tuples made up of two element strings from
+            headers of client response
+        :rtype: List[Tuple[str, str]]
+        """
+        headers_list = []
+        if headers_dict is not None:
+            for key, values in six.iteritems(headers_dict):
+                for value in values.split(","):
+                    value = value.strip()
+                    if value is not None and value is not '':
+                        headers_list.append((key, value.strip()))
+        return headers_list
+

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/api_client_message.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/api_client_message.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+import typing
+
+if typing.TYPE_CHECKING:
+    from typing import List, Tuple
+
+
+class ApiClientMessage(object):
+    """Represents the interface between
+    :py:class:`ask_sdk_model_runtime.api_client.ApiClient` implementation
+    and a Service Client.
+
+    :param headers: List of header tuples
+    :type headers: list[tuple[str, str]]
+    :param body: Body of the message
+    :type body: str
+    """
+
+    def __init__(self, headers=None, body=None):
+        # type: (List[Tuple[str, str]], str) -> None
+        """Represents the interface between
+        :py:class:`ask_sdk_model_runtime.api_client.ApiClient`
+        implementation and a Service Client.
+
+        :param headers: List of header tuples
+        :type headers: list[tuple[str, str]]
+        :param body: Body of the message
+        :type body: str
+        """
+        if headers is None:
+            headers = []
+        self.headers = headers
+        self.body = body

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/api_client_request.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/api_client_request.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+import typing
+
+from .api_client_message import ApiClientMessage
+
+if typing.TYPE_CHECKING:
+    from typing import List, Tuple
+
+
+class ApiClientRequest(ApiClientMessage):
+    """Represents a request sent from Service Clients to an
+    :py:class:`ask_sdk_model_runtime.api_client.ApiClient` implementation.
+
+    :param headers: List of header tuples
+    :type headers: list[tuple[str, str]]
+    :param body: Body of the message
+    :type body: str
+    :param url: Url of the request
+    :type url: str
+    :param method: Method called with the request
+    :type method: str
+    """
+
+    def __init__(self, headers=None, body=None, url=None, method=None):
+        # type: (List[Tuple[str, str]], str, str, str) -> None
+        """Represents a request sent from Service Clients to an
+        :py:class:`ask_sdk_model_runtime.api_client.ApiClient`
+        implementation.
+
+        :param headers: List of header tuples
+        :type headers: list[tuple[str, str]]
+        :param body: Body of the message
+        :type body: str
+        :param url: Url of the request
+        :type url: str
+        :param method: Method called with the request
+        :type method: str
+        """
+        super(ApiClientRequest, self).__init__(headers=headers, body=body)
+        self.url = url
+        self.method = method

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/api_client_response.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/api_client_response.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+import typing
+
+from .api_client_message import ApiClientMessage
+
+if typing.TYPE_CHECKING:
+    from typing import List, Tuple
+
+
+class ApiClientResponse(ApiClientMessage):
+    """Represents a response returned by
+    :py:class:`ask_sdk_model_runtime.api_client.ApiClient` implementation
+    to a Service Client.
+
+    :param headers: List of header tuples
+    :type headers: list[tuple[str, str]]
+    :param body: Body of the message
+    :type body: str
+    :param status_code: Status code of the response
+    :type status_code: int
+    """
+
+    def __init__(self, headers=None, body=None, status_code=None):
+        # type: (List[Tuple[str, str]], str, int) -> None
+        """Represents a response returned by
+        :py:class:`ask_sdk_model_runtime.api_client.ApiClient`
+        implementation to a Service Client.
+
+        :param headers: List of header tuples
+        :type headers: list[tuple[str, str]]
+        :param body: Body of the message
+        :type body: str
+        :param status_code: Status code of the response
+        :type status_code: int
+        """
+        super(ApiClientResponse, self).__init__(headers=headers, body=body)
+        self.status_code = status_code

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/api_configuration.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/api_configuration.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+import typing
+
+if typing.TYPE_CHECKING:
+    from .serializer import Serializer
+    from .api_client import ApiClient
+
+
+class ApiConfiguration(object):
+    """Represents a class that provides API configuration options needed by 
+    service clients. 
+
+    :param serializer: serializer implementation for encoding/decoding JSON
+        from/to Object models.
+    :type serializer: (optional) ask_sdk_model_runtime.serializer.Serializer
+    :param api_client: API Client implementation
+    :type api_client: (optional) ask_sdk_model_runtime.api_client.ApiClient
+    :param authorization_value: Authorization value to be used on any calls of
+        the service client instance
+    :type authorization_value: (optional) str
+    :param api_endpoint: Endpoint to hit by the service client instance
+    :type api_endpoint: (optional) str
+    """
+
+    def __init__(self, serializer=None, api_client=None,
+                 authorization_value=None, api_endpoint=None):
+        # type: (Serializer, ApiClient, str, str) -> None
+        """Represents a class that provides API configuration options needed by
+        service clients.
+
+        :param serializer: serializer implementation for encoding/decoding JSON
+            from/to Object models.
+        :type serializer: (optional) ask_sdk_model_runtime.serializer.Serializer
+        :param api_client: API Client implementation
+        :type api_client: (optional) ask_sdk_model_runtime.api_client.ApiClient
+        :param authorization_value: Authorization value to be used on any calls
+            of the service client instance
+        :type authorization_value: (optional) str
+        :param api_endpoint: Endpoint to hit by the service client instance
+        :type api_endpoint: (optional) str
+        """
+        self.serializer = serializer
+        self.api_client = api_client
+        self.authorization_value = authorization_value
+        self.api_endpoint = api_endpoint

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/api_response.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/api_response.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+import typing
+
+if typing.TYPE_CHECKING:
+    from typing import List, Tuple
+
+
+class ApiResponse(object):
+    """Represents a response returned by the Service Client.
+
+    :param headers: List of header tuples
+    :type headers: list[tuple[str, str]]
+    :param body: Body of the response
+    :type body: object
+    :param status_code: Status code of the response
+    :type status_code: int
+    """
+
+    def __init__(self, headers=None, body=None, status_code=None):
+        # type: (List[Tuple[str, str]], object, int) -> None
+        """Represents a response returned by the Service Client.
+
+        :param headers: List of header tuples
+        :type headers: list[tuple[str, str]]
+        :param body: Body of the response
+        :type body: object
+        :param status_code: Status code of the response
+        :type status_code: int
+        """
+        if headers is None:
+            headers = []
+        self.headers = headers
+        self.body = body
+        self.status_code = status_code

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/authentication_configuration.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/authentication_configuration.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+
+
+class AuthenticationConfiguration(object):
+    """Represents a class that provides authentication configuration.
+
+    :param client_id: Client ID required for authentication.
+    :type client_id: str
+    :param client_secret: Client Secret required for authentication.
+    :type client_secret: str
+    :param refresh_token: Client refresh_token required to get access token
+        for API calls.
+    :type refresh_token: str
+    """
+
+    def __init__(self, client_id=None, client_secret=None, refresh_token=None):
+        # type: (str, str, str) -> None
+        """Represents a class that provides authentication configuration.
+
+        :param client_id: Client ID required for authentication.
+        :type client_id: str
+        :param client_secret: Client Secret required for authentication.
+        :type client_secret: str
+        :param refresh_token: Client refresh_token required to get access token
+            for API calls.
+        :type refresh_token: str
+        """
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.refresh_token = refresh_token

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/base_service_client.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/base_service_client.py
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+import six
+import typing
+from six.moves.urllib.parse import quote
+from six.moves.urllib.parse import urlencode
+
+from .api_client_request import ApiClientRequest
+from .api_response import ApiResponse
+from .exceptions import ServiceException
+
+if six.PY3:
+    unicode_type = str
+else:
+    unicode_type = unicode
+
+if typing.TYPE_CHECKING:
+    from typing import TypeVar, Union, List, Dict, Tuple
+    from .service_client_response import ServiceClientResponse
+    from .api_configuration import ApiConfiguration
+
+    T = TypeVar('T')
+
+
+class BaseServiceClient(object):
+    """Class to be used as the base class for the generated service clients.
+
+    The class has to be implemented by the service clients and this class
+    instantiation is not supported
+
+    :param api_configuration: ApiConfiguration implementation
+    :type api_configuration: ask_sdk_model_runtime.api_configuration.ApiConfiguration
+    """
+
+    def __init__(self, api_configuration):
+        # type: (ApiConfiguration) -> None
+        """Class to be used as the base class for the generated service clients.
+
+        :param api_configuration: ApiConfiguration implementation
+        :type api_configuration: ask_sdk_model_runtime.api_configuration.ApiConfiguration
+        """
+        self._api_client = api_configuration.api_client
+        self._serializer = api_configuration.serializer
+        self._authorization_value = api_configuration.authorization_value
+        self._api_endpoint = api_configuration.api_endpoint
+
+    def invoke(self, method, endpoint, path, query_params, header_params,
+               path_params, response_definitions, body, response_type):
+        # type: (str, str, str, List[Tuple[str, str]], List[Tuple[str, str]], Dict[str, str], List[ServiceClientResponse], T, Union[str, T]) -> Union[None, ApiResponse]
+        """Calls the ApiClient based on the ServiceClient specific data
+        provided as well as handles the well-known responses from the Api.
+
+        :param method: Http method
+        :type method: str
+        :param endpoint: Base endpoint to make the request to
+        :type method: str
+        :param path: Specific path to hit. It might contain variables to be
+            interpolated with path_params
+        :type path: str
+        :param query_params: Parameter values to be sent as part of query string
+        :type query_params: list(tuple(str, str))
+        :param header_params: Parameter values to be sent as headers
+        :type header_params: list(tuple(str, str))
+        :param path_params: Parameter values to be interpolated in the path
+        :type path_params: dict(str, str)
+        :param response_definitions: Well-known expected responses by
+            the ServiceClient
+        :type response_definitions: list(ask_sdk_model_runtime.service_client_response.ServiceClientResponse)
+        :param body: Request body
+        :type body: object
+        :param response_type: Type of the expected response if applicable
+        :type response_type: class
+        :return: ApiResponse object.
+        :rtype: :py:class:`ask_sdk_model_runtime.api_response.py`
+        :raises: :py:class:`ask_sdk_model_runtime.exceptions.ServiceException`
+            if service fails and :py:class:`ValueError` if serializer or API
+            Client is not configured in api_configuration # noqa: E501
+        """
+        request = ApiClientRequest()
+        request.url = BaseServiceClient.__build_url(endpoint=endpoint,
+                                                    path=path,
+                                                    query_params=query_params,
+                                                    path_params=path_params)
+        request.method = method
+        request.headers = header_params
+
+        if self._serializer is None:
+            raise ValueError("Serializer is None")
+
+        if self._api_client is None:
+            raise ValueError("API client is None")
+
+        if body:
+            request.body = self._serializer.serialize(body)
+
+        try:
+            response = self._api_client.invoke(request)
+        except Exception as e:
+            raise ServiceException(
+                message="Call to service failed: {}".format(str(e)),
+                status_code=500, headers=None, body=None)
+
+        if response.status_code is None:
+            raise ServiceException(message="Invalid Response, no status code",
+                                   status_code=500, headers=None, body=None)
+
+        if BaseServiceClient.__is_code_successful(response.status_code):
+            api_response = ApiResponse(headers=response.headers,
+                                       status_code=response.status_code)
+
+            # Body of HTTP 204 (No Content) response should be empty, return
+            # ApiResponse with empty body, since body is not a valid json
+            # value to be deserialized
+            if ((response_type is None) or (
+                    response.status_code == 204 and not response.body)):
+                return api_response
+
+            api_response.body = self._serializer.deserialize(
+                payload=response.body, obj_type=response_type)
+            return api_response
+
+        if response_definitions:
+            exception_metadata_list = ([d for d in response_definitions if
+                                        d.status_code == response.status_code])
+            if exception_metadata_list:
+                exception_metadata = exception_metadata_list[0]
+                exception_body = self._serializer.deserialize(
+                    payload=response.body,
+                    obj_type=exception_metadata.response_type)
+                raise ServiceException(message=exception_metadata.message,
+                                       status_code=exception_metadata.status_code,
+                                       headers=response.headers,
+                                       body=exception_body)
+
+        raise ServiceException(message="Unknown error",
+                               status_code=response.status_code,
+                               headers=response.headers, body=response.body)
+
+    @staticmethod
+    def __is_code_successful(response_code):
+        # type: (int) -> bool
+        """Check if the response is a successful response
+        :type response_code: int
+        :rtype: bool
+        """
+        return 200 <= response_code < 300
+
+    @staticmethod
+    def __interpolate_params(path, path_params):
+        # type: (str, Dict[str, str]) -> str
+        """Interpolate path with path params.
+
+        :param path: Path to send the api call. Could contain variables
+            in {} braces
+        :type path: str
+        :param path_params: Parameters to be interpolated in the path. Keys
+            should match variables specified in the path # noqa: E501
+        :type path_params: dict(str, str)
+        :return: Interpolated path with path param values
+        :rtype: str
+        """
+        if not path_params:
+            return path
+
+        for param_name, param_val in six.iteritems(path_params):
+            path = path.replace('{' + param_name + '}',
+                                quote(str(param_val), safe=''))
+        return path
+
+    @staticmethod
+    def __build_query_string(query_params, is_query_start):
+        # type: (List[Tuple[str, str]], bool) -> str
+        """Build query string from query parameters.
+
+        :param query_params: Parameters sent as part of query string
+        :type query_params: list(tuple(str, str))
+        :param is_query_start: Does query starts with constant
+        :type is_query_start: bool
+        :return: Query string built from query parameters
+        :rtype: str
+        """
+        if not query_params:
+            return ""
+
+        query_string = "&" if is_query_start else "?"
+        encoded_query_params = []
+        for query_param in query_params:
+            param_name = query_param[0]
+            param_value = query_param[1]
+            param_name_encoded = param_name.encode("utf-8") if isinstance(
+                param_name, unicode_type) else param_name
+            param_value_encoded = param_value.encode("utf-8") if isinstance(
+                param_value, unicode_type) else param_value
+            encoded_query_params.append(
+                (param_name_encoded, param_value_encoded))
+
+        return query_string + urlencode(encoded_query_params)
+
+    @staticmethod
+    def __build_url(endpoint, path, query_params, path_params):
+        # type: (str, str, List[Tuple[str, str]], Dict[str, str]) -> str
+        """Build URL from the provided parameters.
+
+        :param endpoint: Endpoint to be sending the api call
+        :type endpoint: str
+        :param path: Path to send the api call. Could contain variables
+            in {} braces
+        :type path: str
+        :param query_params: Query Parameters to be appended to the url
+        :type query_params: list(tuple(str, str)
+        :param path_params: Parameters to be interpolated in the path.
+            Keys should match variables specified in the path # noqa: E501
+        :type path_params: dict(str, str)
+        :return Built url
+        :rtype: str
+        """
+        process_endpoint = (
+            endpoint[:-1] if endpoint.endswith("/") else endpoint)
+        path_with_params = BaseServiceClient.__interpolate_params(path,
+                                                                  path_params)
+        is_constant_query_present = "?" in path_with_params
+        query_string = BaseServiceClient.__build_query_string(query_params,
+                                                              is_constant_query_present)
+
+        return '{}{}{}'.format(process_endpoint, path_with_params,
+                               query_string)

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/base_service_client.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/base_service_client.py
@@ -207,7 +207,7 @@ class BaseServiceClient(object):
             encoded_query_params.append(
                 (param_name_encoded, param_value_encoded))
 
-        return query_string + urlencode(encoded_query_params)
+        return query_string + urlencode(encoded_query_params, doseq=True)
 
     @staticmethod
     def __build_url(endpoint, path, query_params, path_params):

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/exceptions.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/exceptions.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+import typing
+
+if typing.TypeVar:
+    from typing import TypeVar, List, Tuple, Optional
+
+    T = TypeVar('T')
+
+
+class ServiceException(Exception):
+    """Exception thrown by a Service client when an error response was
+    received or some operation failed.
+
+    :param message: Description of the error
+    :type message: str
+    :param status_code: Status code of the HTTP Response
+    :type status_code: int
+    :param headers: Headers of the Http response that return the failure
+    :type headers: list(tuple(str, str))
+    :param body: Body of the HTTP Response
+    :type body: object
+    """
+
+    def __init__(self, message, status_code, headers, body):
+        # type: (str, int, Optional[List[Tuple[str, str]]], Optional[T]) -> None
+        """
+        Exception thrown by a Service client when an error response was
+        received or some operation failed.
+
+        :param message: Description of the error
+        :type message: str
+        :param status_code: Status code of the HTTP Response
+        :type status_code: int
+        :param headers: Headers of the Http response that return the failure
+        :type headers: list(tuple(str, str))
+        :param body: Body of the HTTP Response
+        :type body: object
+        """
+        super(ServiceException, self).__init__(message)
+
+        self.status_code = status_code
+        self.headers = headers
+        self.body = body
+
+
+class SerializationException(Exception):
+    """Class for exceptions raised during
+    serialization/deserialization.
+    """
+    pass
+
+
+class ApiClientException(Exception):
+    """Exception class for ApiClient Adapter processing."""
+    pass

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/lwa/__init__.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/lwa/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+from __future__ import absolute_import
+from .access_token_request import AccessTokenRequest
+from .access_token_response import AccessTokenResponse
+from .access_token import AccessToken
+from .error import Error
+from .lwa_client import LwaClient

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/lwa/access_token.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/lwa/access_token.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+import typing
+
+if typing.TYPE_CHECKING:
+    from datetime import datetime
+
+
+class AccessToken(object):
+    """Represents the access token provided by LWA (Login With Amazon).
+
+    This is a wrapper class over
+    :py:class:`ask_sdk_model_runtime.lwa.access_token_response.AccessTokenResponse`
+    that retrieves and stores the access token, the expiry time from
+    LWA response.
+
+    :param token: access token from LWA
+    :type token: str
+    :param expiry: exact timestamp in UTC datetime, which is the expiry
+        time for this access token. This is set as the combined datetime of
+        current system time when the LWA response is received and the
+        expiry time in seconds, provided in the LWA response.
+    :type expiry: datetime
+    """
+
+    def __init__(self, token=None, expiry=None):
+        # type: (str, datetime) -> None
+        """Represents the access token provided by LWA (Login With Amazon).
+
+        :param token: access token from LWA
+        :type token: str
+        :param expiry: exact timestamp in UTC datetime, which is the expiry
+            time for this access token. This is set as the combined datetime of
+            current system time when the LWA response is received and the
+            expiry time in seconds, provided in the LWA response.
+        :type expiry: datetime
+        """
+        self.token = token
+        self.expiry = expiry

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/lwa/access_token_request.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/lwa/access_token_request.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+import pprint
+import six
+import typing
+from enum import Enum
+
+if typing.TYPE_CHECKING:
+    from typing import Dict, Optional
+
+
+class AccessTokenRequest(object):
+    """Request for retrieving an access token from LWA.
+
+    :param client_id: The ClientId value from developer console
+    :type client_id: str
+    :param client_secret: The ClientSecret value from developer console
+    :type client_secret: str
+    :param scope: The required scope for which the access token is
+        requested for
+    :type scope: str
+    :param refresh_token: Client refresh_token required to get access token
+        for API calls.
+    :type refresh_token: str
+    """
+    deserialized_types = {
+        'client_id': 'str',
+        'client_secret': 'str',
+        'refresh_token': 'str',
+        'scope': 'str'
+    }
+
+    attribute_map = {
+        'client_id': 'client_id',
+        'client_secret': 'client_secret',
+        'refresh_token': 'refresh_token',
+        'scope': 'scope'
+    }
+
+    def __init__(self, client_id=None, client_secret=None, scope=None, refresh_token=None):
+        # type: (Optional[str], Optional[str], Optional[str], Optional[str]) -> None
+        """Request for retrieving an access token from LWA.
+
+        :param client_id: The ClientId value from developer console
+        :type client_id: str
+        :param client_secret: The ClientSecret value from developer console
+        :type client_secret: str
+        :param scope: The required scope for which the access token is
+            requested for
+        :type scope: str
+        :param refresh_token: Client refresh_token required to get access token
+            for API calls.
+        :type refresh_token: str
+        """
+        self.__discriminator_value = None
+
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.scope = scope
+        self.refresh_token = refresh_token
+
+    def to_dict(self):
+        # type: () -> Dict
+        """Returns the model properties as a dict"""
+        result = {}  # type: Dict
+
+        for attr, _ in six.iteritems(self.deserialized_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else
+                    x.value if isinstance(x, Enum) else x, value))
+            elif isinstance(value, Enum):
+                result[attr] = value.value
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict()) if hasattr(
+                        item[1], "to_dict") else (
+                    item[0], item[1].value) if isinstance(item[1],
+                                                          Enum) else item,
+                    value.items()))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        # type: () -> str
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        # type: () -> str
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        # type: (object) -> bool
+        """Returns true if both objects are equal"""
+        if not isinstance(other, AccessTokenRequest):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        # type: (object) -> bool
+        """Returns true if both objects are not equal"""
+        return not self == other

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/lwa/access_token_response.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/lwa/access_token_response.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+import pprint
+import six
+import typing
+from enum import Enum
+
+if typing.TYPE_CHECKING:
+    from typing import Dict, Optional
+
+
+class AccessTokenResponse(object):
+    """LWA response for retrieving an access token.
+
+    :param access_token: The access token from LWA
+    :type access_token: str
+    :param expires_in: The duration in seconds of the access token
+        lifetime
+    :type expires_in: int
+    :param scope: The scope specified in the access token request
+    :type scope: str
+    :param token_type: The type of token issued
+    :type token_type: str
+    """
+    deserialized_types = {
+        'access_token': 'str',
+        'expires_in': 'int',
+        'scope': 'str',
+        'token_type': 'str'
+    }
+
+    attribute_map = {
+        'access_token': 'access_token',
+        'expires_in': 'expires_in',
+        'scope': 'scope',
+        'token_type': 'token_type'
+    }
+
+    def __init__(self, access_token=None, expires_in=None, scope=None, token_type=None):
+        # type: (Optional[str], Optional[int], Optional[str], Optional[str]) -> None
+        """LWA response for retrieving an access token.
+
+        :param access_token: The access token from LWA
+        :type access_token: str
+        :param expires_in: The duration in seconds of the access token
+            lifetime
+        :type expires_in: int
+        :param scope: The scope specified in the access token request
+        :type scope: str
+        :param token_type: The type of token issued
+        :type token_type: str
+        """
+        self.__discriminator_value = None
+
+        self.access_token = access_token
+        self.expires_in = expires_in
+        self.scope = scope
+        self.token_type = token_type
+
+    def to_dict(self):
+        # type: () -> Dict[str, object]
+        """Returns the model properties as a dict"""
+        result = {}  # type: Dict
+
+        for attr, _ in six.iteritems(self.deserialized_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else
+                    x.value if isinstance(x, Enum) else x, value))
+            elif isinstance(value, Enum):
+                result[attr] = value.value
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict()) if hasattr(
+                        item[1], "to_dict") else (
+                    item[0], item[1].value) if isinstance(item[1], Enum) else item,
+                    value.items()))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        # type: () -> str
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        # type: () -> str
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        # type: (object) -> bool
+        """Returns true if both objects are equal"""
+        if not isinstance(other, AccessTokenResponse):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        # type: (object) -> bool
+        """Returns true if both objects are not equal"""
+        return not self == other

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/lwa/error.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/lwa/error.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+import pprint
+import six
+import typing
+from enum import Enum
+
+if typing.TYPE_CHECKING:
+    from typing import Dict, Optional
+
+
+class Error(object):
+    """Error from LWA Client request.
+
+    :param error_description: Description of the error
+    :type error_description: (optional) str
+    :param error_type: Type of error
+    :type error_type: (optional) str
+    """
+    deserialized_types = {
+        'error_description': 'str',
+        'error_type': 'str'
+    }
+
+    attribute_map = {
+        'error_description': 'error_description',
+        'error_type': 'error'
+    }
+
+    def __init__(self, error_description=None, error_type=None):
+        # type: (Optional[str], Optional[str]) -> None
+        """
+        :param error_description: Description of the error
+        :type error_description: (optional) str
+        :param error_type: Type of error
+        :type error_type: (optional) str
+        """
+        self.__discriminator_value = None
+
+        self.error_description = error_description
+        self.error_type = error_type
+
+    def to_dict(self):
+        # type: () -> Dict[str, object]
+        """Returns the model properties as a dict"""
+        result = {}  # type: Dict
+
+        for attr, _ in six.iteritems(self.deserialized_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else
+                    x.value if isinstance(x, Enum) else x, value))
+            elif isinstance(value, Enum):
+                result[attr] = value.value
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict()) if hasattr(
+                        item[1], "to_dict") else (
+                    item[0], item[1].value) if isinstance(item[1],
+                                                          Enum) else item,
+                    value.items()))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        # type: () -> str
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        # type: () -> str
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        # type: (object) -> bool
+        """Returns true if both objects are equal"""
+        if not isinstance(other, Error):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        # type: (object) -> bool
+        """Returns true if both objects are not equal"""
+        return not self == other

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/lwa/lwa_client.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/lwa/lwa_client.py
@@ -1,0 +1,233 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+import typing
+import six
+
+from dateutil import tz
+from datetime import datetime, timedelta
+from ..base_service_client import BaseServiceClient
+from ..service_client_response import ServiceClientResponse
+from .access_token_request import AccessTokenRequest
+from .access_token import AccessToken
+
+if typing.TYPE_CHECKING:
+    from .access_token_response import AccessTokenResponse
+    from ..api_configuration import ApiConfiguration
+    from ..authentication_configuration import AuthenticationConfiguration
+    from typing import Any, Dict, List, Optional
+
+
+class LwaClient(BaseServiceClient):
+    """Client to call Login with Amazon (LWA) to retrieve access tokens.
+
+    :param api_configuration: ApiConfiguration instance with valid
+        Serializer and ApiClient. The authorization value and api endpoint
+        is not used by the LWA Client.
+    :type api_configuration:
+        ask_sdk_model_runtime.api_configuration.ApiConfiguration
+    :param authentication_configuration: AuthenticationConfiguration
+        instance with valid client id and client secret, for making LWA
+        calls.
+    :type authentication_configuration: ask_sdk_model_runtime.authentication_configuration.AuthenticationConfiguration
+    :param grant_type: The grant type which is used to make the HTTP request.
+    :type grant_type: (optional) str
+    :raises: :py:class:`ValueError` if authentication configuration is not
+        provided.
+    """
+    EXPIRY_OFFSET_IN_MILLIS = 60000
+    DEFAULT_LWA_ENDPOINT = "https://api.amazon.com"
+    REFRESH_ACCESS_TOKEN = "refresh_access_token"
+    CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials"
+    LWA_CREDENTIALS_GRANT_TYPE = "refresh_token"
+
+    def __init__(self, api_configuration, authentication_configuration,
+                 grant_type=None):
+        # type: (ApiConfiguration, AuthenticationConfiguration, str) -> None
+        """Client to call Login with Amazon (LWA) to retrieve access tokens.
+
+        :param api_configuration: ApiConfiguration instance with valid
+            Serializer and ApiClient. The authorization value and api endpoint
+            is not used by the LWA Client.
+        :type api_configuration:
+            ask_sdk_model_runtime.services.api_configuration.ApiConfiguration
+        :param authentication_configuration: AuthenticationConfiguration
+            instance with valid client id and client secret, for making LWA
+            calls.
+        :type authentication_configuration: ask_sdk_model_runtime.authentication_configuration.AuthenticationConfiguration
+        :param grant_type: The grant type which is used to make the HTTP request.
+        :type grant_type: (optional) str
+        :raises: :py:class:`ValueError` if authentication configuration is not
+            provided.
+        """
+        super(LwaClient, self).__init__(api_configuration=api_configuration)
+
+        if authentication_configuration is None:
+            raise ValueError("authentication_configuration must be provided")
+        self._authentication_configuration = authentication_configuration
+        if grant_type is None:
+            self._grant_type = self.CLIENT_CREDENTIALS_GRANT_TYPE
+        else:
+            self._grant_type = grant_type
+        self._scoped_token_cache = dict()  # type: Dict
+
+    def get_access_token_from_refresh_token(self):
+        # type: () -> str
+        """Retrieve access token for Skill Management API calls.
+
+        :return: Retrieved access token for the given refresh_token and
+            configured client id, client secret
+        :rtype: str
+        """
+        return self._get_access_token()
+
+    def get_access_token_for_scope(self, scope):
+        # type: (str) -> str
+        """Retrieve access token for given scope.
+
+        :param scope: Target scope for the access token
+        :type scope: str
+        :return: Retrieved access token for the given scope and
+            configured client id, client secret
+        :rtype: str
+        :raises: :py:class:`ValueError` is no scope is passed.
+        """
+        if scope is None:
+            raise ValueError("scope must be provided")
+        return self._get_access_token(scope)
+
+    def _get_access_token(self, scope=None):
+        # type: (str) -> str
+        """Retrieve access token.
+
+        Return the access token from the ``scoped_token_cache``
+        if the token is unexpired. If it is expired or is not present,
+        then retrieve a new access token using the client id, client secret
+        and refresh_token or scope based on API request in the input
+        :py:class:`ask_sdk_model_runtime.authentication_configuration.AuthenticationConfiguration`
+        instance.
+
+        :param scope: Target scope for the access token
+        :type scope: str
+        :return: Retrieved access token for configured client id, client secret
+        :rtype: str
+        :raises: :py:class:`ValueError` is no scope is passed and
+            :py:class:`ValueError` if LWA AccessTokenResponse is None.
+        """
+        if scope is None:
+            cache_key = self.REFRESH_ACCESS_TOKEN
+        else:
+            cache_key = scope
+
+        access_token = self._scoped_token_cache.get(cache_key, None)
+        local_now = datetime.now(tz.tzutc())
+
+        if (access_token is not None and access_token.expiry > local_now
+                + timedelta(milliseconds=self.EXPIRY_OFFSET_IN_MILLIS)):
+            return access_token.token
+
+        access_token_request = AccessTokenRequest(
+            client_id=self._authentication_configuration.client_id,
+            client_secret=self._authentication_configuration.client_secret)
+
+        if self._authentication_configuration.refresh_token is None:
+            access_token_request.scope = scope
+        else:
+            access_token_request.refresh_token = (
+                self._authentication_configuration.refresh_token)
+
+        lwa_response = self._generate_access_token(
+            access_token_request=access_token_request)
+
+        if lwa_response is None or lwa_response.expires_in is None:
+            raise ValueError("Invalid response from LWA Client generate "
+                             "access token call")
+
+        access_token = AccessToken(token=lwa_response.access_token,
+            expiry=local_now + timedelta(seconds=lwa_response.expires_in))
+
+        self._scoped_token_cache[cache_key] = access_token
+        return access_token.token
+
+    def _generate_access_token(self, access_token_request, **kwargs):
+        # type: (AccessTokenRequest, **Any) -> Optional[AccessTokenResponse]
+        """Generate access token by calling the LWA API.
+
+        :param access_token_request: The access token request with client
+            information that is used during the API call.
+        :type access_token_request:
+            ask_sdk_model_runtime.lwa.access_token_request.AccessTokenRequest
+        :return: The access token response from the LWA call.
+        :rtype:
+            ask_sdk_model_runtime.lwa.access_token_response.AccessTokenResponse
+        """
+        operation_name = "get_access_token"
+        params = locals()
+        for key, val in six.iteritems(params['kwargs']):
+            params[key] = val
+        del params['kwargs']
+
+        if self._api_endpoint:
+            endpoint = self._api_endpoint
+        else:
+            endpoint = self.DEFAULT_LWA_ENDPOINT
+        resource_path = '/auth/O2/token'.replace('{format}', 'json')
+        path_params = {}  # type: Dict
+        query_params = []  # type: List
+        header_params = [('Content-type', 'application/x-www-form-urlencoded')]
+
+        grant_type_param = "grant_type={}".format(self._grant_type)
+        client_id_param = "client_id={}".format(access_token_request.client_id)
+        client_secret_param = "client_secret={}".format(
+            access_token_request.client_secret)
+
+        body_params = "&".join(
+            [grant_type_param, client_id_param, client_secret_param])
+        if self._grant_type == self.LWA_CREDENTIALS_GRANT_TYPE:
+            param_info = "refresh_token={}".format(
+                access_token_request.refresh_token)
+        else:
+            param_info = "scope={}".format(access_token_request.scope)
+        body_params += "&{}".format(param_info)
+        error_definitions = list()  # type: List
+        error_definitions.append(ServiceClientResponse(
+            response_type=("ask_sdk_model_runtime.services.lwa.access_token_response."
+                           "AccessTokenResponse"), status_code=200,
+            message="Success"))
+        error_definitions.append(ServiceClientResponse(
+            response_type="ask_sdk_model_runtime.services.lwa.error.Error",
+            status_code=400, message="Bad Request"))
+        error_definitions.append(ServiceClientResponse(
+            response_type="ask_sdk_model_runtime.services.lwa.error.Error",
+            status_code=401, message="Authentication failed"))
+        error_definitions.append(ServiceClientResponse(
+            response_type="ask_sdk_model_runtime.services.lwa.error.Error",
+            status_code=500, message="Internal Server Error"))
+        error_definitions.append(ServiceClientResponse(
+            response_type="ask_sdk_model_runtime.services.lwa.error.Error",
+            status_code=503, message="Service Unavailable"))
+
+        api_response = self.invoke(method="POST", endpoint=endpoint,
+                                   path=resource_path, path_params=path_params,
+                                   query_params=query_params,
+                                   header_params=header_params,
+                                   body=body_params,
+                                   response_definitions=error_definitions,
+                                   response_type=("ask_sdk_model_runtime.lwa."
+                                                  "access_token_response."
+                                                  "AccessTokenResponse"))
+        return api_response.body  # type: ignore

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/lwa/lwa_client.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/lwa/lwa_client.py
@@ -64,7 +64,7 @@ class LwaClient(BaseServiceClient):
             Serializer and ApiClient. The authorization value and api endpoint
             is not used by the LWA Client.
         :type api_configuration:
-            ask_sdk_model_runtime.services.api_configuration.ApiConfiguration
+            ask_sdk_model_runtime.api_configuration.ApiConfiguration
         :param authentication_configuration: AuthenticationConfiguration
             instance with valid client id and client secret, for making LWA
             calls.
@@ -205,20 +205,20 @@ class LwaClient(BaseServiceClient):
         body_params += "&{}".format(param_info)
         error_definitions = list()  # type: List
         error_definitions.append(ServiceClientResponse(
-            response_type=("ask_sdk_model_runtime.services.lwa.access_token_response."
+            response_type=("ask_sdk_model_runtime.lwa.access_token_response."
                            "AccessTokenResponse"), status_code=200,
             message="Success"))
         error_definitions.append(ServiceClientResponse(
-            response_type="ask_sdk_model_runtime.services.lwa.error.Error",
+            response_type="ask_sdk_model_runtime.lwa.error.Error",
             status_code=400, message="Bad Request"))
         error_definitions.append(ServiceClientResponse(
-            response_type="ask_sdk_model_runtime.services.lwa.error.Error",
+            response_type="ask_sdk_model_runtime.lwa.error.Error",
             status_code=401, message="Authentication failed"))
         error_definitions.append(ServiceClientResponse(
-            response_type="ask_sdk_model_runtime.services.lwa.error.Error",
+            response_type="ask_sdk_model_runtime.lwa.error.Error",
             status_code=500, message="Internal Server Error"))
         error_definitions.append(ServiceClientResponse(
-            response_type="ask_sdk_model_runtime.services.lwa.error.Error",
+            response_type="ask_sdk_model_runtime.lwa.error.Error",
             status_code=503, message="Service Unavailable"))
 
         api_response = self.invoke(method="POST", endpoint=endpoint,

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/serializer.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/serializer.py
@@ -1,0 +1,426 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+import sys
+import re
+import json
+import typing
+import decimal
+from datetime import date, datetime
+from abc import ABCMeta, abstractmethod
+
+from six import iteritems
+from six import text_type
+from six import integer_types
+from enum import Enum
+
+from typing import cast, Any
+
+from .exceptions import SerializationException
+
+unicode_type = text_type
+
+try:
+    long  # type: ignore
+except NameError:
+    long = int
+
+if typing.TYPE_CHECKING:
+    from typing import TypeVar, Dict, List, Tuple, Union, Any
+    T = TypeVar('T')
+
+
+class Serializer(object):
+    """Represents an abstract object used for Serialization tasks."""
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def serialize(self, obj):
+        # type: (T) -> str
+        """Serializes an object into a string.
+
+        :param obj: object to serialize
+        :return: serialized object in string format
+        :rtype: str
+        """
+        pass
+
+    @abstractmethod
+    def deserialize(self, payload, obj_type):
+        # type: (Optional[str], Union[str,T]) -> T
+        """Deserializes the payload to object of provided obj_type.
+
+        :param payload: String to deserialize
+        :type payload: str
+        :param obj_type: Target type of deserialization
+        :type obj_type: object
+        :return: Deserialized object
+        :rtype: object
+        """
+        pass
+
+
+class DefaultSerializer(Serializer):
+    PRIMITIVE_TYPES = (float, bool, bytes, text_type) + integer_types
+    NATIVE_TYPES_MAPPING = {
+        'int': int,
+        'long': long,
+        'float': float,
+        'str': str,
+        'bool': bool,
+        'date': date,
+        'datetime': datetime,
+        'object': object,
+    }
+
+    def serialize(self, obj):  # type: ignore
+        # type: (Any) -> Union[Dict[str, Any], List, Tuple, str, int, float, bytes, None]
+        """Builds a serialized object.
+
+        * If obj is None, return None.
+        * If obj is str, int, long, float, bool, return directly.
+        * If obj is datetime.datetime, datetime.date convert to
+          string in iso8601 format.
+        * If obj is list, serialize each element in the list.
+        * If obj is dict, return the dict with serialized values.
+        * If obj is ask sdk model, return the dict with keys resolved
+          from the union of model's ``attribute_map`` and
+          ``deserialized_types`` and values serialized based on
+          ``deserialized_types``.
+        * If obj is a generic class instance, return the dict with keys
+          from instance's ``deserialized_types`` and values serialized
+          based on ``deserialized_types``.
+
+        :param obj: The data to serialize.
+        :type obj: object
+        :return: The serialized form of data.
+        :rtype: Union[Dict[str, Any], List, Tuple, str, int, float, bytes, None]
+        """
+        if obj is None:
+            return None
+        elif isinstance(obj, self.PRIMITIVE_TYPES):
+            return obj
+        elif isinstance(obj, list):
+            return [self.serialize(sub_obj) for sub_obj in obj]
+        elif isinstance(obj, tuple):
+            return tuple(self.serialize(sub_obj) for sub_obj in obj)
+        elif isinstance(obj, (datetime, date)):
+            return obj.isoformat()
+        elif isinstance(obj, Enum):
+            return obj.value
+        elif isinstance(obj, decimal.Decimal):
+            if obj % 1 == 0:
+                return int(obj)
+            else:
+                return float(obj)
+
+        if isinstance(obj, dict):
+            obj_dict = obj
+        else:
+            # Convert model obj to dict
+            # All the non null attributes under `deserialized_types`
+            # map are considered for serialization.
+            # The `attribute_map` provides the key names to be used
+            # in the dict. In case of missing `attribute_map` mapping,
+            # the original attribute name is retained as the key name.
+            class_attribute_map = getattr(obj, 'attribute_map', {})
+            class_attribute_map.update(
+                {
+                    k: k for k in obj.deserialized_types.keys()
+                    if k not in class_attribute_map
+                }
+            )
+
+            obj_dict = {
+                class_attribute_map[attr]: getattr(obj, attr)
+                for attr, _ in iteritems(obj.deserialized_types)
+                if getattr(obj, attr) is not None
+            }
+
+        return {key: self.serialize(val) for key, val in iteritems(obj_dict)}
+
+    def deserialize(self, payload, obj_type):
+        # type: (str, Union[T, str]) -> Any
+        """Deserializes payload into an instance of provided ``obj_type``.
+
+        The ``obj_type`` parameter can be a primitive type, a generic
+        model object or a list / dict of model objects.
+
+        The list or dict object type has to be provided as a string
+        format. For eg:
+
+        * ``'list[a.b.C]'`` if the payload is a list of instances of
+          class ``a.b.C``.
+        * ``'dict(str, a.b.C)'`` if the payload is a dict containing
+          mappings of ``str : a.b.C`` class instance types.
+
+        The method looks for a ``deserialized_types`` dict in the model
+        class, that mentions which payload values has to be
+        deserialized. In case the payload key names are different than
+        the model attribute names, the corresponding mapping can be
+        provided in another special dict ``attribute_map``. The model
+        class should also have the ``__init__`` method with default
+        values for arguments. Check
+        :py:class:`ask_sdk_model.request_envelope.RequestEnvelope`
+        source code for an example implementation.
+
+        :param payload: data to be deserialized.
+        :type payload: str
+        :param obj_type: resolved class name for deserialized object
+        :type obj_type: Union[object, str]
+        :return: deserialized object
+        :rtype: object
+        :raises: :py:class:`ask_sdk_model_runtime.exceptions.SerializationException`
+        """
+        if payload is None:
+            return None
+
+        try:
+            payload = json.loads(payload)
+        except Exception:
+            raise SerializationException(
+                "Couldn't parse response body: {}".format(payload))
+
+        return self.__deserialize(payload, obj_type)
+
+    def __deserialize(self, payload, obj_type):
+        # type: (str, Union[T, str]) -> Any
+        """Deserializes payload into a model object.
+
+        :param payload: data to be deserialized.
+        :type payload: str
+        :param obj_type: resolved class name for deserialized object
+        :type obj_type: Union[object, str]
+        :return: deserialized object
+        :rtype: object
+        """
+        if payload is None:
+            return None
+
+        if isinstance(obj_type, str):
+            if obj_type.startswith('list['):
+                # Get object type for each item in the list
+                # Deserialize each item using the object type.
+                sub_obj_type =  re.match(
+                    'list\[(.*)\]', obj_type)
+                if sub_obj_type is None:
+                    return []
+                sub_obj_types = sub_obj_type.group(1)
+                deserialized_list = []  # type: List
+                if "," in sub_obj_types:
+                    # list contains objects of different types
+                    for sub_payload, sub_obj_types in zip(
+                            payload, sub_obj_types.split(",")):
+                        deserialized_list.append(self.__deserialize(
+                            sub_payload, sub_obj_types.strip()))
+                else:
+                    for sub_payload in payload:
+                        deserialized_list.append(self.__deserialize(
+                            sub_payload, sub_obj_types.strip()))
+                return deserialized_list
+
+            if obj_type.startswith('dict('):
+                # Get object type for each k,v pair in the dict
+                # Deserialize each value using the object type of v.
+                sub_obj_type = re.match(
+                    'dict\(([^,]*), (.*)\)', obj_type)
+                if sub_obj_type is None:
+                    return {}
+                sub_obj_types = sub_obj_type.group(2)
+                return {
+                    k: self.__deserialize(v, sub_obj_types)
+                    for k, v in iteritems(cast(Any, payload))
+                }
+            # convert str to class
+            if obj_type in self.NATIVE_TYPES_MAPPING:
+                obj_type = self.NATIVE_TYPES_MAPPING[obj_type]  # type: ignore
+            else:
+                # deserialize models
+                obj_type = self.__load_class_from_name(obj_type)
+
+        if obj_type in self.PRIMITIVE_TYPES:
+            return self.__deserialize_primitive(payload, obj_type)
+        elif obj_type == object:
+            return payload
+        elif obj_type == date:
+            return self.__deserialize_datetime(payload, obj_type)
+        elif obj_type == datetime:
+            return self.__deserialize_datetime(payload, obj_type)
+        else:
+            return self.__deserialize_model(payload, obj_type)
+
+    def __load_class_from_name(self, class_name):
+        # type: (str) -> T
+        """Load the class from the ``class_name`` provided.
+
+        Resolve the class name from the ``class_name`` provided, load
+        the class on path and return the resolved class. If the module
+        information is not provided in the ``class_name``, then look
+        for the class on sys ``modules``.
+
+        :param class_name: absolute class name to be loaded
+        :type class_name: str
+        :return: Resolved class reference
+        :rtype: object
+        :raises: :py:class:`ask_sdk_model_runtime.exceptions.SerializationException`
+        """
+        try:
+            module_class_list = class_name.rsplit(".", 1)
+            if len(module_class_list) > 1:
+                module_name = module_class_list[0]
+                resolved_class_name = module_class_list[1]
+                module = __import__(
+                    module_name, fromlist=[resolved_class_name])
+                resolved_class = getattr(module, resolved_class_name)
+            else:
+                resolved_class_name = module_class_list[0]
+                resolved_class = getattr(
+                    sys.modules[__name__], resolved_class_name)
+            return resolved_class
+        except Exception as e:
+            raise SerializationException(
+                "Unable to resolve class {} from installed "
+                "modules: {}".format(class_name, str(e)))
+
+    def __deserialize_primitive(self, payload, obj_type):
+        # type: (str, Union[T, str]) -> Any
+        """Deserialize primitive datatypes.
+
+        :param payload: data to be deserialized
+        :type payload: str
+        :param obj_type: primitive datatype str
+        :type obj_type: Union[object, str]
+        :return: deserialized primitive datatype object
+        :rtype: object
+        :raises: :py:class:`ask_sdk_model_runtime.exceptions.SerializationException`
+        """
+        obj_cast = cast(Any, obj_type)
+        try:
+            return obj_cast(payload)
+        except UnicodeEncodeError:
+            return unicode_type(payload)
+        except TypeError:
+            return payload
+        except ValueError:
+            raise SerializationException(
+                "Failed to parse {} into '{}' object".format(
+                    payload, obj_cast.__name__))
+
+    def __deserialize_datetime(self, payload, obj_type):
+        # type: (str, Union[T, str]) -> Any
+        """Deserialize datetime instance in ISO8601 format to
+        date/datetime object.
+
+        :param payload: data to be deserialized in ISO8601 format
+        :type payload: str
+        :param obj_type: primitive datatype str
+        :type obj_type: Union[object, str]
+        :return: deserialized primitive datatype object
+        :rtype: object
+        :raises: :py:class:`ask_sdk_model_runtime.exceptions.SerializationException`
+        """
+        obj_cast = cast(Any, obj_type)
+        try:
+            from dateutil.parser import parse
+            parsed_datetime = parse(payload)
+            if obj_type is date:
+                return parsed_datetime.date()
+            else:
+                return parsed_datetime
+        except ImportError:
+            return payload
+        except ValueError:
+            raise SerializationException(
+                "Failed to parse {} into '{}' object".format(
+                    payload, obj_cast.__name__))
+
+    def __deserialize_model(self, payload, obj_type):
+        # type: (str, Union[T, str]) -> Any
+        """Deserialize instance to model object.
+
+        :param payload: data to be deserialized
+        :type payload: str
+        :param obj_type: sdk model class
+        :type obj_type: Union[object, str]
+        :return: deserialized sdk model object
+        :rtype: object
+        :raises: :py:class:`ask_sdk_model_runtime.exceptions.SerializationException`
+        """
+        try:
+            obj_cast = cast(Any, obj_type)
+            if issubclass(obj_cast, Enum):
+                return obj_cast(payload)
+
+            if hasattr(obj_cast, 'deserialized_types'):
+                if hasattr(obj_cast, 'get_real_child_model'):
+                    obj_cast = self.__get_obj_by_discriminator(
+                        payload, obj_cast)
+
+                class_deserialized_types = obj_cast.deserialized_types
+                class_attribute_map = getattr(obj_cast, 'attribute_map', {})
+                class_attribute_map.update(
+                    {
+                        k: k for k in obj_cast.deserialized_types.keys()
+                        if k not in class_attribute_map
+                    }
+                )
+
+                deserialized_model = obj_cast()
+                for class_param_name, payload_param_name in iteritems(
+                        class_attribute_map):
+                    if payload_param_name in payload:
+                        setattr(
+                            deserialized_model,
+                            class_param_name,
+                            self.__deserialize(
+                                payload[payload_param_name],
+                                class_deserialized_types[class_param_name]))
+
+                additional_params = [
+                    param for param in payload
+                    if param not in class_attribute_map.values()]
+
+                for add_param in additional_params:
+                    setattr(deserialized_model, add_param, payload[cast(Any,add_param)])
+                return deserialized_model
+            else:
+                return payload
+        except Exception as e:
+            raise SerializationException(str(e))
+
+    def __get_obj_by_discriminator(self, payload, obj_type):
+        # type: (str, Union[T, str]) -> T
+        """Get correct subclass instance using the discriminator in
+        payload.
+
+        :param payload: Payload for deserialization
+        :type payload: str
+        :param obj_type: parent class for deserializing payload into
+        :type obj_type: Union[object, str]
+        :return: Subclass of provided parent class, that resolves to
+            the discriminator in payload.
+        :rtype: object
+        :raises: :py:class:`ask_sdk_model_runtime.exceptions.SerializationException`
+        """
+        obj_cast = cast(Any, obj_type)
+        namespaced_class_name = obj_cast.get_real_child_model(payload)
+        if not namespaced_class_name:
+            raise SerializationException(
+                "Couldn't resolve object by discriminator type "
+                "for {} class".format(obj_type))
+
+        return self.__load_class_from_name(namespaced_class_name)

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/serializer.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/serializer.py
@@ -40,7 +40,7 @@ except NameError:
     long = int
 
 if typing.TYPE_CHECKING:
-    from typing import TypeVar, Dict, List, Tuple, Union, Any
+    from typing import TypeVar, Dict, List, Tuple, Union, Optional, Any
     T = TypeVar('T')
 
 

--- a/ask-sdk-model-runtime/ask_sdk_model_runtime/service_client_response.py
+++ b/ask-sdk-model-runtime/ask_sdk_model_runtime/service_client_response.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+import typing
+
+if typing.TYPE_CHECKING:
+    from typing import TypeVar
+
+    T = TypeVar('T')
+
+
+class ServiceClientResponse(object):
+    """Represents a well-known response object by Service Client.
+
+    :param response_type: Well-known representation of the response
+    :type response_type: Response class
+    :param status_code: Status code to be attached to the response
+    :type status_code: int
+    :param message: Message to be attached to the response
+    :type message: str
+    """
+
+    def __init__(self, response_type, status_code, message):
+        # type: (T, int, str) -> None
+        """
+        Represents a well-known response object by Service Client.
+
+        :param response_type: Well-known representation of the response
+        :type response_type: Response class
+        :param status_code: Status code to be attached to the response
+        :type status_code: int
+        :param message: Message to be attached to the response
+        :type message: str
+        """
+        self.response_type = response_type
+        self.status_code = status_code
+        self.message = message

--- a/ask-sdk-model-runtime/requirements.txt
+++ b/ask-sdk-model-runtime/requirements.txt
@@ -1,0 +1,2 @@
+requests
+python_dateutil

--- a/ask-sdk-model-runtime/setup.cfg
+++ b/ask-sdk-model-runtime/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/ask-sdk-model-runtime/setup.py
+++ b/ask-sdk-model-runtime/setup.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+import os
+from setuptools import setup, find_packages
+from codecs import open
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+about = {}
+with open(os.path.join(
+        here, 'ask_sdk_model_runtime', '__version__.py'), 'r', 'utf-8') as f:
+    exec(f.read(), about)
+
+with open('README.rst', 'r', 'utf-8') as f:
+    readme = f.read()
+with open('CHANGELOG.rst', 'r', 'utf-8') as f:
+    history = f.read()
+
+setup(
+    name=about['__pip_package_name__'],
+    version=about['__version__'],
+    description=about['__description__'],
+    long_description=readme + '\n\n' + history,
+    author=about['__author__'],
+    author_email=about['__author_email__'],
+    url=about['__url__'],
+    keywords=about['__keywords__'],
+    license=about['__license__'],
+    include_package_data=True,
+    install_requires=about['__install_requires__'],
+    packages=find_packages(
+        exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
+    zip_safe=False,
+    classifiers=(
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7'
+    ),
+    python_requires=(">2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, "
+                     "!=3.5.*"),
+)

--- a/ask-sdk-model-runtime/tests/__init__.py
+++ b/ask-sdk-model-runtime/tests/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+import os
+import sys
+sys.path.insert(
+    0, os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '..', 'ask_sdk_model_runtime')))

--- a/ask-sdk-model-runtime/tests/unit/__init__.py
+++ b/ask-sdk-model-runtime/tests/unit/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#

--- a/ask-sdk-model-runtime/tests/unit/data/__init__.py
+++ b/ask-sdk-model-runtime/tests/unit/data/__init__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+
+from .model_enum_object import ModelEnumObject
+from .model_test_object_1 import ModelTestObject1
+from .model_test_object_2 import ModelTestObject2
+from .model_test_object_3 import ModelTestObject3
+from .model_test_object_4 import ModelTestObject4
+from .invalid_model_object import InvalidModelObject
+from .model_abstract_parent_object import ModelAbstractParentObject
+from .model_child_objects import ModelChildObject1
+from .model_child_objects import ModelChildObject2

--- a/ask-sdk-model-runtime/tests/unit/data/invalid_model_object.py
+++ b/ask-sdk-model-runtime/tests/unit/data/invalid_model_object.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+
+
+class InvalidModelObject(object):
+    def __init__(self, some_var=None):
+        self.some_var = some_var
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__

--- a/ask-sdk-model-runtime/tests/unit/data/mock_response_object.py
+++ b/ask-sdk-model-runtime/tests/unit/data/mock_response_object.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+
+
+class MockResponse(object):
+    def __init__(self, json_data, status_code, headers=None):
+        self.json_data = json_data
+        self.status_code = status_code
+        self.headers = headers
+
+        self.text = self.json_data

--- a/ask-sdk-model-runtime/tests/unit/data/model_abstract_parent_object.py
+++ b/ask-sdk-model-runtime/tests/unit/data/model_abstract_parent_object.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+from abc import ABCMeta, abstractmethod
+
+
+class ModelAbstractParentObject(object):
+    __metaclass__ = ABCMeta
+
+    deserialized_types = {
+        'child_type': 'str',
+        'str_var': 'str',
+        'obj_var': 'tests.unit.data.ModelTestObject2',
+    }
+
+    attribute_map = {
+        'child_type': 'ChildType',
+        'str_var': 'var1',
+        'obj_var': 'var3Object',
+    }
+
+    discriminator_value_class_map = {
+        'ChildType1': 'tests.unit.data.ModelChildObject1',
+        'ChildType2': 'tests.unit.data.ModelChildObject2'
+    }
+
+    json_discriminator_key = "ChildType"
+
+    @abstractmethod
+    def __init__(self, child_type=None, str_var=None, obj_var=None):
+        self.child_type = child_type
+        self.str_var = str_var
+        self.obj_var = obj_var
+
+    @classmethod
+    def get_real_child_model(cls, data):
+        """Returns the real base class specified by the discriminator"""
+        discriminator_value = data[cls.json_discriminator_key]
+        return cls.discriminator_value_class_map.get(discriminator_value)

--- a/ask-sdk-model-runtime/tests/unit/data/model_child_objects.py
+++ b/ask-sdk-model-runtime/tests/unit/data/model_child_objects.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+import six
+
+from .model_abstract_parent_object import ModelAbstractParentObject
+
+
+class ModelChildObject1(ModelAbstractParentObject):
+    deserialized_types = {
+        'child_type': 'str',
+        'str_var': 'str',
+        'obj_var': 'tests.unit.data.ModelTestObject2',
+        'test_var': 'str'
+    }
+
+    attribute_map = {
+        'child_type': 'ChildType',
+        'str_var': 'var1',
+        'obj_var': 'var3Object',
+        'test_var': 'testVar'
+    }
+
+    def __init__(self, str_var=None, obj_var=None, test_var=None):
+        super(ModelChildObject1, self).__init__(child_type="ChildType1", str_var=str_var, obj_var=obj_var)
+        self.test_var = test_var
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+
+class ModelChildObject2(ModelAbstractParentObject):
+    deserialized_types = {
+        'child_type': 'str',
+        'str_var': 'str',
+        'obj_var': 'tests.unit.data.ModelTestObject2',
+        'test_int_var': 'int'
+    }
+
+    attribute_map = {
+        'child_type': 'ChildType',
+        'str_var': 'var1',
+        'obj_var': 'var3Object',
+        'test_int_var': 'testIntVar'
+    }
+
+    def __init__(self, str_var=None, obj_var=None, test_int_var=None):
+        super(ModelChildObject2, self).__init__(child_type="ChildType2", str_var=str_var, obj_var=obj_var)
+        self.test_int_var = test_int_var
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__

--- a/ask-sdk-model-runtime/tests/unit/data/model_enum_object.py
+++ b/ask-sdk-model-runtime/tests/unit/data/model_enum_object.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+from enum import Enum
+
+
+class ModelEnumObject(Enum):
+    ENUM_VAL_1 = "ENUM_VAL_1"
+    ENUM_VAL_2 = "ENUM_VAL_2"
+
+    def __eq__(self, other):
+        return self.value == other.value

--- a/ask-sdk-model-runtime/tests/unit/data/model_test_object_1.py
+++ b/ask-sdk-model-runtime/tests/unit/data/model_test_object_1.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+
+
+class ModelTestObject1(object):
+    deserialized_types = {
+        'str_var': 'str',
+        'datetime_var': 'datetime',
+        'obj_var': 'tests.unit.data.ModelTestObject2',
+        'none_var': 'None',
+        'enum_var': 'tests.unit.data.ModelEnumObject'
+    }
+
+    attribute_map = {
+        'str_var': 'var1',
+        'datetime_var': 'var2Time',
+        'obj_var': 'var3Object',
+        'none_var': 'var5None',
+        'enum_var': 'var6Enum'
+    }
+
+    def __init__(self, str_var=None, datetime_var=None, obj_var=None, none_var=None, enum_var=None):
+        self.str_var = str_var
+        self.datetime_var = datetime_var
+        self.obj_var = obj_var
+        self.none_var = none_var
+        self.enum_var = enum_var
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__

--- a/ask-sdk-model-runtime/tests/unit/data/model_test_object_2.py
+++ b/ask-sdk-model-runtime/tests/unit/data/model_test_object_2.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+
+
+class ModelTestObject2(object):
+    deserialized_types = {
+        'int_var': 'int'
+    }
+
+    attribute_map = {
+        'int_var': 'var4Int'
+    }
+
+    def __init__(self, int_var=None):
+        self.int_var = int_var
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__

--- a/ask-sdk-model-runtime/tests/unit/data/model_test_object_3.py
+++ b/ask-sdk-model-runtime/tests/unit/data/model_test_object_3.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+
+
+class ModelTestObject3(object):
+    deserialized_types = {
+        'str_var': 'str',
+        'int_var': 'int'
+    }
+
+    def __init__(self, str_var=None, int_var=None):
+        self.str_var = str_var
+        self.int_var = int_var
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__

--- a/ask-sdk-model-runtime/tests/unit/data/model_test_object_4.py
+++ b/ask-sdk-model-runtime/tests/unit/data/model_test_object_4.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+
+
+class ModelTestObject4(object):
+    deserialized_types = {
+        'str_var': 'str',
+        'float_var': 'float'
+    }
+
+    attribute_map = {
+        'float_var': 'floatingValue'
+    }
+
+    def __init__(self, str_var=None, float_var=None):
+        self.str_var = str_var
+        self.float_var = float_var
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__

--- a/ask-sdk-model-runtime/tests/unit/test_api_client.py
+++ b/ask-sdk-model-runtime/tests/unit/test_api_client.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+import unittest
+import json
+
+from ask_sdk_model_runtime import (
+    ApiClientRequest, DefaultApiClient, ApiClientException)
+
+from .data.mock_response_object import MockResponse
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+
+class TestDefaultApiClient(unittest.TestCase):
+    def setUp(self):
+        self.valid_request = ApiClientRequest(
+            method="GET", url="https://test.com", body=None, headers=None)
+        self.valid_mock_response = MockResponse(
+            json_data="some test data", status_code=200)
+        self.test_api_client = DefaultApiClient()
+
+    def test_convert_null_header_tuples_to_dict(self):
+        test_headers_list = None
+        expected_headers_dict = {}
+
+        assert self.test_api_client._convert_list_tuples_to_dict(
+            test_headers_list) == expected_headers_dict, (
+            "DefaultApiClient failed to convert null headers list to empty "
+            "dict object")
+
+    def test_convert_header_tuples_to_dict(self):
+        test_headers_list = [
+            ("header_1", "test_1"), ("header_2", "test_2"),
+            ("header_1", "test_3")]
+        expected_headers_dict = {
+            "header_1": "test_1, test_3", "header_2": "test_2"}
+
+        assert self.test_api_client._convert_list_tuples_to_dict(
+            test_headers_list) == expected_headers_dict, (
+            "DefaultApiClient failed to convert header list of tuples to "
+            "dictionary format needed for http "
+            "request call")
+
+    def test_convert_null_header_dict_to_tuples(self):
+        test_headers_dict = None
+        expected_headers_list = []
+
+        assert self.test_api_client._convert_dict_to_list_tuples(
+            test_headers_dict) == expected_headers_list, (
+            "DefaultApiClient failed to convert null headers dict to empty "
+            "list object")
+
+    def test_convert_header_dict_to_tuples(self):
+        test_headers_dict = {
+            "header_1": "test_1, test_3", "header_2": "test_2",
+            "header_3": "test_4,"}
+        expected_headers_list = [
+            ("header_1", "test_1"), ("header_1", "test_3"),
+            ("header_2", "test_2"), ("header_3", "test_4")]
+
+        assert set(self.test_api_client._convert_dict_to_list_tuples(
+            test_headers_dict)) == set(
+            expected_headers_list), (
+            "DefaultApiClient failed to convert headers dict to list of "
+            "tuples format for ApiClientResponse")
+
+    def test_resolve_valid_http_method(self):
+        with mock.patch("requests.get",
+                        side_effect=lambda *args, **kwargs:
+                        self.valid_mock_response):
+            try:
+                actual_response = self.test_api_client.invoke(
+                    self.valid_request)
+            except:
+                # Should never reach here
+                raise Exception("DefaultApiClient couldn't resolve valid "
+                                "HTTP Method for calling")
+
+    def test_resolve_invalid_http_method_throw_exception(self):
+        test_invalid_method_request = ApiClientRequest(
+            method="GET_TEST", url="http://test.com", body=None, headers=None)
+
+        with mock.patch("requests.get",
+                        side_effect=lambda *args, **kwargs:
+                        self.valid_mock_response):
+            with self.assertRaises(ApiClientException) as exc:
+                self.test_api_client.invoke(test_invalid_method_request)
+
+            assert "Invalid request method: GET_TEST" in str(exc.exception)
+
+    def test_invoke_http_method_throw_exception(self):
+        with mock.patch("requests.get",
+                        side_effect=Exception("test exception")):
+            with self.assertRaises(ApiClientException) as exc:
+                self.test_api_client.invoke(self.valid_request)
+
+            assert "Error executing the request: test exception" in str(exc.exception)
+
+    def test_api_client_invoke_with_method_headers_processed(self):
+        self.valid_request.headers = [
+            ("request_header_1", "test_1"), ("request_header_2", "test_2"),
+            ("request_header_1", "test_3")]
+        self.valid_request.method = "PUT"
+
+        test_response = MockResponse(
+            headers={
+                "response_header_1": "test_1, test_3",
+                "response_header_2": "test_2", "response_header_3": "test_4,"},
+            status_code=400,
+            json_data="test response body")
+
+        with mock.patch("requests.put",
+                        side_effect=lambda *args, **kwargs: test_response):
+            actual_response = self.test_api_client.invoke(self.valid_request)
+
+            assert set(actual_response.headers) == set([
+                ("response_header_1", "test_1"),
+                ("response_header_1", "test_3"),
+                ("response_header_2", "test_2"),
+                ("response_header_3", "test_4")]), (
+                "Response headers from client doesn't match with the "
+                "expected headers")
+
+            assert actual_response.status_code == 400, (
+                "Status code from client response doesn't match with the "
+                "expected response status code")
+
+            assert actual_response.body == "test response body", (
+                "Body from client response doesn't match with the expected "
+                "response body")
+
+    def test_api_client_invoke_with_http_url_throw_error(self):
+        test_invalid_url_scheme_request = ApiClientRequest(
+            method="GET", url="http://test.com", body=None, headers=None)
+
+        with mock.patch("requests.get",
+                        side_effect=lambda *args, **kwargs:
+                        self.valid_mock_response):
+            with self.assertRaises(ApiClientException) as exc:
+                self.test_api_client.invoke(test_invalid_url_scheme_request)
+
+            assert "Requests against non-HTTPS endpoints are not allowed." in str(exc.exception)
+
+    def test_api_client_invoke_with_http_case_sensitive_url_throw_error(self):
+        test_invalid_url_scheme_request = ApiClientRequest(
+            method="GET", url="HTTP://test.com", body=None, headers=None)
+
+        with mock.patch("requests.get",
+                        side_effect=lambda *args, **kwargs:
+                        self.valid_mock_response):
+            with self.assertRaises(ApiClientException) as exc:
+                self.test_api_client.invoke(test_invalid_url_scheme_request)
+
+            assert "Requests against non-HTTPS endpoints are not allowed." in str(exc.exception)
+
+    def test_api_client_invoke_with_no_url_schema_throw_error(self):
+        test_invalid_url_scheme_request = ApiClientRequest(
+            method="GET", url="test.com", body=None, headers=None)
+
+        with mock.patch("requests.get",
+                        side_effect=lambda *args, **kwargs:
+                        self.valid_mock_response):
+            with self.assertRaises(ApiClientException) as exc:
+                self.test_api_client.invoke(test_invalid_url_scheme_request)
+
+            assert "Requests against non-HTTPS endpoints are not allowed." in str(exc.exception)
+
+    def test_api_client_send_request_with_raw_data_serialized_for_json_content(
+            self):
+        test_data = "test\nstring"
+        self.valid_request.body = "test\nstring"
+        self.valid_request.method = "POST"
+        headers = [("Content-type", "application/json")]
+        self.valid_request.headers = headers
+
+        with mock.patch(
+                "requests.post",
+                side_effect=lambda *args, **kwargs: self.valid_mock_response
+        ) as mock_put:
+            actual_response = self.test_api_client.invoke(self.valid_request)
+            mock_put.assert_called_once_with(
+                data=json.dumps(test_data),
+                headers={'Content-type': 'application/json'},
+                url=self.valid_request.url)
+
+    def test_api_client_send_request_with_raw_data_unchanged_for_non_json_content(
+            self):
+        test_data = "test\nstring"
+        self.valid_request.body = "test\nstring"
+        self.valid_request.method = "POST"
+
+        with mock.patch(
+                "requests.post",
+                side_effect=lambda *args, **kwargs: self.valid_mock_response
+        ) as mock_put:
+            actual_response = self.test_api_client.invoke(self.valid_request)
+            mock_put.assert_called_once_with(
+                data=test_data, headers={},
+                url=self.valid_request.url)

--- a/ask-sdk-model-runtime/tests/unit/test_base_service_client.py
+++ b/ask-sdk-model-runtime/tests/unit/test_base_service_client.py
@@ -1,0 +1,523 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+#
+import six
+from pytest import raises
+
+from ask_sdk_model_runtime import (ApiClient, ApiClientResponse, ApiConfiguration,
+ BaseServiceClient, Serializer, ServiceException, ServiceClientResponse)
+
+if six.PY3:
+    from unittest import mock
+else:
+    import mock
+
+
+class MockedApiClient(ApiClient):
+    def invoke(self, request):
+        self.request = request
+        return self.empty_response()
+
+    def empty_response(self):
+        fake_response = ApiClientResponse()
+        fake_response.status_code = 200
+        return fake_response
+
+
+class MockedBaseServiceClient(object):
+    @staticmethod
+    def empty_response():
+        mocked_api_client = MockedApiClient()
+        mocked_serializer = mock.MagicMock(spec=Serializer)
+        api_configuration = ApiConfiguration(
+            serializer=mocked_serializer, api_client=mocked_api_client,
+            authorization_value="test_token", api_endpoint="test_endpoint")
+        return BaseServiceClient(api_configuration=api_configuration)
+
+    @staticmethod
+    def service_client_null_api_client():
+        mocked_serializer = mock.MagicMock(spec=Serializer)
+        api_configuration = ApiConfiguration(
+            serializer=mocked_serializer, api_client=None,
+            authorization_value="test_token", api_endpoint="test_endpoint")
+        return BaseServiceClient(api_configuration=api_configuration)
+        
+    @staticmethod
+    def service_client_null_serializer():
+        mocked_api_client = MockedApiClient()
+        api_configuration = ApiConfiguration(
+            serializer=None, api_client=mocked_api_client,
+            authorization_value="test_token", api_endpoint="test_endpoint")
+        return BaseServiceClient(api_configuration=api_configuration)
+
+
+class TestBaseServiceClient(object):
+    def test_invoke_build_url_with_path_when_endpoint_path_passed(
+            self):
+        mocked_api_client = MockedApiClient()
+        mocked_serializer = mock.MagicMock(spec=Serializer)
+        endpoint = "http://test.com"
+        path = "/v1/x/y"
+        expected = "http://test.com/v1/x/y"
+
+        mocked_base_service_client_api_client_empty_response = MockedBaseServiceClient.empty_response()
+        mocked_base_service_client_api_client_empty_response.invoke(
+            method="GET", endpoint=endpoint, path=path, query_params=[],
+            header_params=[], path_params={},response_definitions=[],
+            body=None, response_type=None)
+
+        assert mocked_base_service_client_api_client_empty_response._api_client.request.url == expected,\
+            "Build URL failed when endpoint and path passed"
+
+    def test_invoke_build_url_with_no_duplicate_slash_path_when_endpoint_path_has_slash(self):
+        endpoint = "http://test.com/"
+        path = "/v1/x/y"
+        expected = "http://test.com/v1/x/y"
+
+        mocked_base_service_client_api_client_empty_response = MockedBaseServiceClient.empty_response()
+        mocked_base_service_client_api_client_empty_response.invoke(
+            method="GET", endpoint=endpoint, path=path, query_params=[],
+            header_params=[], path_params={}, response_definitions=[],
+            body=None, response_type=None)
+
+        assert mocked_base_service_client_api_client_empty_response._api_client.request.url == expected,\
+            "Build URL failed when endpoint and path with duplicate slash passed"
+
+    def test_invoke_build_url_with_query_params(
+            self):
+        endpoint = "http://test.com/"
+        path = "/v1/x/y/"
+        query_params = [("filter", "test_filter"), ("select", "test_select"),
+                        ("value", "test_value")]
+        expected = "http://test.com/v1/x/y/?filter=test_filter&" \
+                   "select=test_select&value=test_value"
+        mocked_base_service_client_api_client_empty_response = MockedBaseServiceClient.empty_response()
+        mocked_base_service_client_api_client_empty_response.invoke(
+            method="GET", endpoint=endpoint, path=path,
+            query_params=query_params, header_params=[], path_params={},
+            response_definitions=[], body=None, response_type=None)
+
+        assert mocked_base_service_client_api_client_empty_response._api_client.request.url == expected,\
+            "Build URL failed when endpoint, path and query parameters passed"
+
+    def test_invoke_build_url_with_query_params_special_chars(
+            self):
+        endpoint = "http://test.com/"
+        path = "/v1/x/y/"
+        query_params = [(u"å", u"∫"), ("test", "test message with $ < > values")]
+        expected = "http://test.com/v1/x/y/?%C3%A5=%E2%88%AB&" \
+                   "test=test+message+with+%24+%3C+%3E+values"
+
+        mocked_base_service_client_api_client_empty_response = MockedBaseServiceClient.empty_response()
+        mocked_base_service_client_api_client_empty_response.invoke(
+            method="GET", endpoint=endpoint, path=path,
+            query_params=query_params, header_params=[], path_params={},
+            response_definitions=[], body=None, response_type=None)
+
+        assert mocked_base_service_client_api_client_empty_response._api_client.request.url == expected,\
+            "Build URL failed when endpoint, path and query parameters containing special characters passed"
+
+    def test_invoke_build_url_with_query_params_static_content(
+            self):
+        endpoint = "http://test.com/"
+        path = "/v1/x/y/?a=b"
+        query_params = [("c", "d")]
+        expected = "http://test.com/v1/x/y/?a=b&c=d"
+
+        mocked_base_service_client_api_client_empty_response = MockedBaseServiceClient.empty_response()
+        mocked_base_service_client_api_client_empty_response.invoke(
+            method="GET", endpoint=endpoint, path=path,
+            query_params=query_params, header_params=[], path_params={},
+            response_definitions=[], body=None, response_type=None)
+
+        assert mocked_base_service_client_api_client_empty_response._api_client.request.url == expected,\
+            "Build URL failed when endpoint, path and query parameters containing static content passed"
+
+    def test_invoke_build_url_with_path_params_interpolated(
+            self):
+        endpoint = "http://test.com/"
+        path = "/v1/{x_id}/y/{z_value}"
+        path_params = {
+            "x_id": "x",
+            "z_value": "z"
+        }
+        expected = "http://test.com/v1/x/y/z"
+
+        mocked_base_service_client_api_client_empty_response = MockedBaseServiceClient.empty_response()
+        mocked_base_service_client_api_client_empty_response.invoke(
+            method="GET", endpoint=endpoint, path=path, query_params=[],
+            header_params=[], path_params=path_params, response_definitions=[],
+            body=None, response_type=None)
+
+        assert mocked_base_service_client_api_client_empty_response._api_client.request.url == expected,\
+            "Build URL failed when endpoint, path and path parameters passed"
+
+    def test_invoke_build_url_with_path_params_containing_special_chars_interpolated(
+            self):
+        endpoint = "http://test.com/"
+        path = "/v1/{x_id}/y/{z_value}"
+        path_params = {
+            "x_id": "å",
+            "z_value": "∫"
+        }
+        expected = "http://test.com/v1/%C3%A5/y/%E2%88%AB"
+
+        mocked_base_service_client_api_client_empty_response = MockedBaseServiceClient.empty_response()
+        mocked_base_service_client_api_client_empty_response.invoke(
+            method="GET", endpoint=endpoint, path=path, query_params=[],
+            header_params=[], path_params=path_params, response_definitions=[],
+            body=None, response_type=None)
+
+        assert mocked_base_service_client_api_client_empty_response._api_client.request.url == expected,\
+            "Build URL failed when endpoint, path and path parameters containing special characters passed"
+
+    def test_invoke_build_url_with_path_params_with_path_ending_in_slash(
+            self):
+        endpoint = "http://test.com/"
+        path = "/v1/x/y/"
+        expected = "http://test.com/v1/x/y/"
+
+        mocked_base_service_client_api_client_empty_response = MockedBaseServiceClient.empty_response()
+        mocked_base_service_client_api_client_empty_response.invoke(
+            method="GET", endpoint=endpoint, path=path, query_params=[],
+            header_params=[], path_params={}, response_definitions=[],
+            body=None, response_type=None)
+
+        assert mocked_base_service_client_api_client_empty_response._api_client.request.url == expected,\
+            "Build URL failed when endpoint, path with ending slash passed"
+
+    def test_invoke_serializes_body_when_passed(self):
+        mocked_api_client = MockedApiClient()
+        mocked_serializer = mock.MagicMock(spec=Serializer)
+        mocked_serializer.serialize.return_value = "serialized_payload"
+        fake_body = mock.Mock()
+        fake_api_config = ApiConfiguration(
+            serializer=mocked_serializer, api_client=mocked_api_client,
+            authorization_value="test_token", api_endpoint="test_endpoint")
+        fake_base_service_client = BaseServiceClient(api_configuration=fake_api_config)
+
+        fake_base_service_client.invoke(
+            method="GET", endpoint="http://test.com", path="", query_params=[],
+            header_params=[], path_params={}, response_definitions=[],
+            body=fake_body, response_type=None)
+
+        mocked_serializer.serialize.assert_called_with(fake_body)
+
+    def test_invoke_serializes_body_not_run_for_null_body(self):
+        mocked_api_client = MockedApiClient()
+        mocked_serializer = mock.MagicMock(spec=Serializer)
+        fake_api_config = ApiConfiguration(
+            serializer=mocked_serializer, api_client=mocked_api_client,
+            authorization_value="test_token", api_endpoint="test_endpoint")
+        fake_base_service_client = BaseServiceClient(api_configuration=fake_api_config)
+
+        fake_base_service_client.invoke(
+            method="GET", endpoint="http://test.com", path="", query_params=[],
+            header_params=[], path_params={}, response_definitions=[],
+            body=None, response_type=None)
+
+        assert not mocked_serializer.serialize.called, "Invoke called serializer for null body"
+
+    def test_invoke_api_client_throws_exception(self):
+        mocked_serializer = mock.MagicMock(spec=Serializer)
+        fake_api_client = mock.MagicMock(spec=ApiClient)
+        fake_api_client.invoke.side_effect = Exception("test exception")
+
+        fake_api_config = ApiConfiguration(
+            serializer=mocked_serializer, api_client=fake_api_client,
+            authorization_value="test_token", api_endpoint="test_endpoint")
+        fake_base_service_client = BaseServiceClient(api_configuration=fake_api_config)
+
+        with raises(ServiceException) as exc:
+            fake_base_service_client.invoke(
+                method="GET", endpoint="http://test.com", path="",
+                query_params=[], header_params=[], path_params={},
+                response_definitions=[], body=None, response_type=None)
+
+        assert str(exc.value) == "Call to service failed: test exception", \
+            "Service exception not raised during base service client invoke when api client invoke raises"
+        assert exc.value.status_code == 500, (
+            "Service exception raised during base service client invoke has different status code than expected, "
+            "when api client invoke raises")
+
+    def test_invoke_serializes_response_if_present(self):
+        mocked_serializer = mock.MagicMock(spec=Serializer)
+        fake_response = ApiClientResponse()
+        fake_response.body = "test_body"
+        fake_response.status_code = 200
+        fake_response_type = "test_response_type"
+
+        fake_api_client = mock.MagicMock(spec=ApiClient)
+        fake_api_client.invoke.return_value = fake_response
+
+        mocked_serializer.deserialize.return_value = "deserialized_payload"
+
+        fake_api_config = ApiConfiguration(
+            serializer=mocked_serializer, api_client=fake_api_client,
+            authorization_value="test_token", api_endpoint="test_endpoint")
+        fake_base_service_client = BaseServiceClient(
+            api_configuration=fake_api_config)
+
+        response = fake_base_service_client.invoke(
+            method="GET", endpoint="http://test.com", path="", query_params=[],
+            header_params=[], path_params={}, response_definitions=[],
+            body=None, response_type=fake_response_type)
+
+        assert response.body == "deserialized_payload", "Response from api client not deserialized by base service client"
+        mocked_serializer.deserialize.assert_called_with(payload=fake_response.body, obj_type=fake_response_type), \
+            "Base service client called deserialize on Response from api client with wrong values"
+
+    def test_invoke_return_api_response_for_no_content_response(self):
+        mocked_serializer = mock.MagicMock(spec=Serializer)
+        fake_response = ApiClientResponse()
+        fake_response.body = ""
+        fake_response.status_code = 204
+        fake_response_type = "test_response_type"
+
+        fake_api_client = mock.MagicMock(spec=ApiClient)
+        fake_api_client.invoke.return_value = fake_response
+
+        fake_api_config = ApiConfiguration(
+            serializer=mocked_serializer, api_client=fake_api_client,
+            authorization_value="test_token", api_endpoint="test_endpoint")
+        fake_base_service_client = BaseServiceClient(
+            api_configuration=fake_api_config)
+
+        response = fake_base_service_client.invoke(
+            method="GET", endpoint="http://test.com", path="", query_params=[],
+            header_params=[], path_params={}, response_definitions=[],
+            body=None, response_type=fake_response_type)
+
+        assert response.body is None, "Base service client returns invalid response when status code is 204"
+        assert response.status_code == 204, "Base service client returns invalid status code"
+        assert not mocked_serializer.deserialize.called, (
+            "Base service client invoke method deserialized no content response body")
+
+    def test_invoke_return_full_api_response(self):
+        mocked_serializer = mock.MagicMock(spec=Serializer)
+        fake_response = ApiClientResponse()
+        fake_response.body = "test_body"
+        fake_response.status_code = 200
+        fake_response.headers = "test_headers"
+        fake_response_type = "test_response_type"
+
+        fake_api_client = mock.MagicMock(spec=ApiClient)
+        fake_api_client.invoke.return_value = fake_response
+
+        fake_api_config = ApiConfiguration(
+            serializer=mocked_serializer, api_client=fake_api_client,
+            authorization_value="test_token", api_endpoint="test_endpoint")
+        fake_base_service_client = BaseServiceClient(
+            api_configuration=fake_api_config)
+
+        mocked_serializer.deserialize.return_value = "deserialized_payload"
+
+        response = fake_base_service_client.invoke(
+            method="GET", endpoint="http://test.com", path="", query_params=[],
+            header_params=[], path_params={}, response_definitions=[],
+            body=None, response_type=fake_response_type)
+
+        assert response.body == "deserialized_payload", ("Base service client returns invalid api response when status code is 204")
+        assert response.headers == "test_headers", ("Base service client return invalid api response with null headers")
+        assert response.status_code == 200, ("Base service client return invalid api response with null status_code")
+
+    def test_invoke_return_api_response_with_none_body(self):
+        mocked_serializer = mock.MagicMock(spec=Serializer)
+        fake_response = ApiClientResponse()
+        fake_response.body = ""
+        fake_response.status_code = 204
+        fake_response.headers = "test_headers"
+        fake_response_type = "test_response_type"
+
+        fake_api_client = mock.MagicMock(spec=ApiClient)
+        fake_api_client.invoke.return_value = fake_response
+
+        fake_api_config = ApiConfiguration(
+            serializer=mocked_serializer, api_client=fake_api_client,
+            authorization_value="test_token", api_endpoint="test_endpoint")
+        fake_base_service_client = BaseServiceClient(
+            api_configuration=fake_api_config)
+
+        response = fake_base_service_client.invoke(
+            method="GET", endpoint="http://test.com", path="", query_params=[],
+            header_params=[], path_params={}, response_definitions=[],
+            body=None, response_type=fake_response_type)
+
+        assert response.body is None, ("Base service client returns invalid api response when status code is 204")
+        assert response.headers == "test_headers", ("Base service client return invalid api response with null headers")
+        assert response.status_code == 204, ("Base service client return invalid api response with null status_code")
+
+        assert not mocked_serializer.deserialize.called, (
+            "Base service client invoke method deserialized no content response body")
+
+    def test_invoke_throw_exception_if_no_definitions_provided_for_unsuccessful_response(self):
+        mocked_serializer = mock.MagicMock(spec=Serializer)
+        fake_response = ApiClientResponse()
+        fake_response.status_code = 450
+
+        fake_api_client = mock.MagicMock(spec=ApiClient)
+        fake_api_client.invoke.return_value = fake_response
+
+        fake_api_config = ApiConfiguration(
+            serializer=mocked_serializer, api_client=fake_api_client,
+            authorization_value="test_token", api_endpoint="test_endpoint")
+        fake_base_service_client = BaseServiceClient(api_configuration=fake_api_config)
+
+        with raises(ServiceException) as exc:
+            fake_base_service_client.invoke(
+                method="GET", endpoint="http://test.com", path="",
+                query_params=[], header_params=[], path_params={},
+                response_definitions=[], body=None, response_type=None)
+
+        assert str(exc.value) == "Unknown error", (
+            "Service exception not raised during base service client invoke when response is unsuccessful and "
+            "no response definitions provided")
+        assert exc.value.status_code == 450, (
+            "Service exception raised during base service client invoke has different status code than expected, "
+            "when response is unsuccessful and no response definitions provided")
+
+    def test_invoke_throw_exception_with_matched_definition_for_unsuccessful_response(self):
+        mocked_serializer = mock.MagicMock(spec=Serializer)
+        fake_response = ApiClientResponse()
+        fake_response.status_code = 450
+        fake_response.body = "test_body"
+
+        fake_api_client = mock.MagicMock(spec=ApiClient)
+        fake_api_client.invoke.return_value = fake_response
+
+        mocked_serializer.deserialize.return_value = "deserialized_error_body"
+
+        fake_api_config = ApiConfiguration(
+            serializer=mocked_serializer, api_client=fake_api_client,
+            authorization_value="test_token", api_endpoint="test_endpoint")
+        fake_base_service_client = BaseServiceClient(
+            api_configuration=fake_api_config)
+
+        fake_response_definition_1 = ServiceClientResponse(
+            response_type="test_definition_1", status_code=450,
+            message="test exception with definition 1")
+        fake_response_definition_2 = ServiceClientResponse(
+            response_type="test_definition_2", status_code=475,
+            message="test exception with definition 2")
+        fake_response_definitions = [fake_response_definition_2, fake_response_definition_1]
+
+        with raises(ServiceException) as exc:
+            fake_base_service_client.invoke(
+                method="GET", endpoint="http://test.com", path="",
+                query_params=[], header_params=[],path_params={},
+                response_definitions=fake_response_definitions,
+                body=None, response_type=None)
+
+        assert str(exc.value) == "test exception with definition 1", (
+            "Incorrect service exception raised during base service client invoke when response is unsuccessful and "
+            "matching response definitions provided")
+        mocked_serializer.deserialize.assert_called_with(
+            payload=fake_response.body, obj_type="test_definition_1")
+        assert str(exc.value.body) == "deserialized_error_body", (
+            "Service exception raised during base service client invoke, when response is unsuccessful, "
+            "has different body that expected response")
+
+    def test_invoke_throw_exception_with_no_matched_definition_for_unsuccessful_response(self):
+        mocked_serializer = mock.MagicMock(spec=Serializer)
+        fake_response = ApiClientResponse()
+        fake_response.status_code = 485
+        fake_response.body = "test_body"
+
+        fake_api_client = mock.MagicMock(spec=ApiClient)
+        fake_api_client.invoke.return_value = fake_response
+
+        fake_api_config = ApiConfiguration(
+            serializer=mocked_serializer, api_client=fake_api_client,
+            authorization_value="test_token", api_endpoint="test_endpoint")
+        fake_base_service_client = BaseServiceClient(
+            api_configuration=fake_api_config)
+
+        fake_response_definition_1 = ServiceClientResponse(
+            response_type="test_definition_1", status_code=450,
+            message="test exception with definition 1")
+        fake_response_definition_2 = ServiceClientResponse(
+            response_type="test_definition_2", status_code=475,
+            message="test exception with definition 2")
+        fake_response_definitions = [fake_response_definition_2, fake_response_definition_1]
+
+        with raises(ServiceException) as exc:
+            fake_base_service_client.invoke(
+                method="GET", endpoint="http://test.com", path="",
+                query_params=[], header_params=[], path_params={},
+                response_definitions=fake_response_definitions,
+                body=None, response_type=None)
+
+        assert str(exc.value) == "Unknown error", (
+            "Incorrect service exception raised during base service client invoke when response is unsuccessful and "
+            "no matching response definitions found")
+        assert str(exc.value.body) == "test_body", (
+            "Service exception raised during base service client invoke, when response is unsuccessful, "
+            "has different body that expected response")
+        assert exc.value.status_code == 485, (
+            "Service exception raised during base service client invoke, when response is unsuccessful, "
+            "has different status code that expected response")
+
+    def test_invoke_raises_value_error_with_none_api_client(self):
+        endpoint = "http://test.com"
+        path = "/v1/x/y"
+
+        with raises(ValueError) as exc:
+            mocked_base_service_client_api_client_none = MockedBaseServiceClient.service_client_null_api_client()
+            mocked_base_service_client_api_client_none.invoke(
+                method="GET", endpoint=endpoint, path=path, query_params=[],
+                header_params=[], path_params={}, response_definitions=[],
+                body=None, response_type=None)
+
+        assert str(exc.value) == 'API client is None', (
+            "Base Service Client was initialized with no api client"
+        )
+
+    def test_invoke_raises_value_error_with_none_serializer(
+            self):
+        endpoint = "http://test.com"
+        path = "/v1/x/y"
+
+        with raises(ValueError) as exc:
+            mocked_base_service_client_serializer_none = MockedBaseServiceClient.service_client_null_serializer()
+            mocked_base_service_client_serializer_none.invoke(
+                method="GET", endpoint=endpoint, path=path, query_params=[],
+                header_params=[], path_params={}, response_definitions=[],
+                body=None, response_type=None)
+
+        assert str(exc.value) == 'Serializer is None', (
+            "Base Service Client was initialized with no serializer"
+        )
+
+    def test_invoke_throw_exception_if_no_response_status_code(self):
+        mocked_serializer = mock.MagicMock(spec=Serializer)
+        fake_response = ApiClientResponse()
+        fake_response.status_code = None
+
+        fake_api_client = mock.MagicMock(spec=ApiClient)
+        fake_api_client.invoke.return_value = fake_response
+
+        fake_api_config = ApiConfiguration(
+            serializer=mocked_serializer, api_client=fake_api_client,
+            authorization_value="test_token", api_endpoint="test_endpoint")
+        fake_base_service_client = BaseServiceClient(
+            api_configuration=fake_api_config)
+
+        with raises(ServiceException) as exc:
+            fake_base_service_client.invoke(
+                method="GET", endpoint="http://test.com", path="",
+                query_params=[], header_params=[], path_params={},
+                response_definitions=[], body=None, response_type=None)
+
+        assert str(exc.value) == "Invalid Response, no status code", (
+            "Service exception raised during base service client invoke, when response is unsuccessful, "
+            "has no status code")

--- a/ask-sdk-model-runtime/tests/unit/test_lwa_client.py
+++ b/ask-sdk-model-runtime/tests/unit/test_lwa_client.py
@@ -1,0 +1,303 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+import six
+
+from dateutil import tz
+import datetime
+from pytest import raises
+
+from ask_sdk_model_runtime import (
+    ApiClient, ApiClientResponse, ApiConfiguration,
+    AuthenticationConfiguration, Serializer, ServiceException)
+from ask_sdk_model_runtime.lwa import (
+    AccessToken, AccessTokenResponse, LwaClient)
+
+if six.PY3:
+    from unittest import mock
+else:
+    import mock
+
+
+class MockedApiClient(ApiClient):
+    def __init__(self):
+        self.request = None
+
+    def invoke(self, request):
+        self.request = request
+        return self.empty_response()
+
+    def empty_response(self):
+        fake_response = ApiClientResponse()
+        fake_response.status_code = 200
+        return fake_response
+
+
+class TestBaseServiceClient(object):
+    def test_lwa_client_init_no_auth_config_throw_exception(self):
+        with raises(ValueError) as exc:
+            lwa_client = LwaClient(
+                api_configuration=ApiConfiguration(),
+                authentication_configuration=None)
+
+        assert str(exc.value) == (
+            "authentication_configuration must be provided"), (
+            "LwaClient Initialization didn't throw exception if a null "
+            "Authentication Configuration is passed")
+
+    def test_get_access_token_for_null_scope_throw_exception(self):
+        test_lwa_client = LwaClient(
+            api_configuration=ApiConfiguration(),
+            authentication_configuration=AuthenticationConfiguration())
+
+        with raises(ValueError) as exc:
+            test_lwa_client.get_access_token_for_scope(scope=None)
+
+        assert str(exc.value) == "scope must be provided", (
+            "LWA Client get access token call didn't throw exception if a "
+            "null scope is passed")
+
+    def test_get_access_token_retrieve_from_cache(self):
+        test_lwa_client = LwaClient(
+            api_configuration=ApiConfiguration(),
+            authentication_configuration=AuthenticationConfiguration())
+        test_scope = "test"
+        expected_token_value = "test_token"
+        test_token_expiry = (
+                datetime.datetime.now(tz.tzutc()) +
+                datetime.timedelta(hours=1))
+        test_access_token = AccessToken(
+            token=expected_token_value, expiry=test_token_expiry)
+
+        test_lwa_client._scoped_token_cache[test_scope] = test_access_token
+
+        actual_token_value = test_lwa_client.get_access_token_for_scope(
+            scope=test_scope)
+
+        assert expected_token_value == actual_token_value, (
+            "LWA Client get access token call didn't retrieve unexpired "
+            "scoped access token from cache when available")
+
+    def test_get_access_token_cache_miss_api_call_success(self):
+        mocked_api_client = MockedApiClient()
+        mocked_serializer = mock.MagicMock(spec=Serializer)
+        mocked_serializer.serialize.return_value = "access token request"
+        local_now = datetime.datetime.now(tz.tzutc())
+        test_scope = "test"
+        test_client_id = "test_client_id"
+        test_client_secret = "test_client_secret"
+
+        expected_token_value = "test_token"
+        expected_headers = [(
+            'Content-type', 'application/x-www-form-urlencoded')]
+        expected_request_method = "POST"
+        expected_request_url = "https://api.amazon.com/auth/O2/token"
+        expected_request_body = (
+            "grant_type=client_credentials&client_id={}&client_secret={}"
+            "&scope={}").format(test_client_id, test_client_secret, test_scope)
+
+        mocked_serializer.deserialize.return_value = AccessTokenResponse(
+            access_token=expected_token_value, expires_in=10, scope=test_scope)
+
+        test_lwa_client = LwaClient(
+            api_configuration=ApiConfiguration(
+                serializer=mocked_serializer,
+                api_client=mocked_api_client),
+            authentication_configuration=AuthenticationConfiguration(
+                client_id=test_client_id,
+                client_secret=test_client_secret))
+
+        with mock.patch(
+                "ask_sdk_model_runtime.lwa.lwa_client.datetime") as mock_date:
+            mock_date.now.return_value = local_now
+            actual_token_value = test_lwa_client.get_access_token_for_scope(
+                scope=test_scope)
+
+        assert expected_token_value == actual_token_value, (
+            "LWA Client get access token call didn't retrieve scoped access token")
+
+        actual_token_expiry = test_lwa_client._scoped_token_cache[
+            test_scope].expiry
+
+        assert (local_now + datetime.timedelta(
+            seconds=10)) == actual_token_expiry, (
+            "LWA Client get access token call cached wrong access token "
+            "expiry date")
+
+        assert mocked_api_client.request.headers == expected_headers, (
+            "LWA Client get access token called API with wrong headers")
+        assert mocked_api_client.request.method == expected_request_method, (
+            "LWA Client get access token called API with wrong HTTP method")
+        assert mocked_api_client.request.url == expected_request_url, (
+            "LWA Client get access token called API with wrong HTTP URL")
+        mocked_serializer.serialize.assert_called_with(expected_request_body)
+
+    def test_get_access_token_for_smapi_cache_miss_api_call_success(
+            self):
+        mocked_api_client = MockedApiClient()
+        mocked_serializer = mock.MagicMock(spec=Serializer)
+        mocked_serializer.serialize.return_value = "access token request"
+        local_now = datetime.datetime.now(tz.tzutc())
+        refresh_access_token = "refresh_access_token"
+        test_refresh_token = "test_refresh_token"
+        test_grant_type = "refresh_token"
+        test_client_id = "test_client_id"
+        test_client_secret = "test_client_secret"
+
+        expected_token_value = "test_token"
+        expected_headers = [(
+            'Content-type', 'application/x-www-form-urlencoded')]
+        expected_request_method = "POST"
+        expected_request_url = "https://api.amazon.com/auth/O2/token"
+        expected_request_body = (
+            "grant_type={}&client_id={}&client_secret={}"
+            "&refresh_token={}").format(test_grant_type, test_client_id,
+                                        test_client_secret, test_refresh_token)
+
+        mocked_serializer.deserialize.return_value = AccessTokenResponse(
+            access_token=expected_token_value, expires_in=10, scope=None)
+
+        test_lwa_client = LwaClient(
+            api_configuration=ApiConfiguration(
+                serializer=mocked_serializer,
+                api_client=mocked_api_client),
+            authentication_configuration=AuthenticationConfiguration(
+                client_id=test_client_id,
+                client_secret=test_client_secret,
+                refresh_token=test_refresh_token),
+            grant_type=test_grant_type
+            )
+
+        with mock.patch(
+                "ask_sdk_model_runtime.lwa.lwa_client.datetime") as mock_date:
+            mock_date.now.return_value = local_now
+            actual_token_value = test_lwa_client.get_access_token_from_refresh_token()
+
+        assert expected_token_value == actual_token_value, (
+            "LWA Client get access token call didn't retrieve unexpired "
+            "scoped access token from cache when available")
+
+        actual_token_expiry = test_lwa_client._scoped_token_cache[
+            refresh_access_token].expiry
+
+        assert (local_now + datetime.timedelta(
+            seconds=10)) == actual_token_expiry, (
+            "LWA Client get access token call cached wrong access token "
+            "expiry date")
+
+        assert mocked_api_client.request.headers == expected_headers, (
+            "LWA Client get access token called API with wrong headers")
+        assert mocked_api_client.request.method == expected_request_method, (
+            "LWA Client get access token called API with wrong HTTP method")
+        assert mocked_api_client.request.url == expected_request_url, (
+            "LWA Client get access tokbbr"
+            "en called API with wrong HTTP URL")
+        mocked_serializer.serialize.assert_called_with(expected_request_body)
+
+
+    def test_get_access_token_for_default_endpoint_api_success(
+            self):
+        mocked_api_client = MockedApiClient()
+        mocked_serializer = mock.MagicMock(spec=Serializer)
+        mocked_serializer.serialize.return_value = "access token request"
+        local_now = datetime.datetime.now(tz.tzutc())
+        test_scope = "test"
+        test_client_id = "test_client_id"
+        test_client_secret = "test_client_secret"
+        test_endpoint = "https://foo.com"
+
+        expected_token_value = "test_token"
+        expected_request_url = "{}/auth/O2/token".format(test_endpoint)
+
+        mocked_serializer.deserialize.return_value = AccessTokenResponse(
+            access_token=expected_token_value, expires_in=10, scope=test_scope)
+
+        test_lwa_client = LwaClient(
+            api_configuration=ApiConfiguration(
+                serializer=mocked_serializer,
+                api_client=mocked_api_client, 
+                api_endpoint=test_endpoint),
+            authentication_configuration=AuthenticationConfiguration(
+                client_id=test_client_id,
+                client_secret=test_client_secret))
+
+        with mock.patch(
+                "ask_sdk_model_runtime.lwa.lwa_client.datetime") as mock_date:
+            mock_date.now.return_value = local_now
+            actual_token_value = test_lwa_client.get_access_token_for_scope(
+                scope=test_scope)
+
+        assert expected_token_value == actual_token_value, (
+            "LWA Client get access token call didn't retrieve scoped access "
+            "token when a custom endpoint is passed")
+
+        assert mocked_api_client.request.url == expected_request_url, (
+            "LWA Client get access token called API with wrong HTTP URL, "
+            "when a custom endpoint is passed")
+
+    def test_get_access_token_api_call_fails_throws_exception(
+            self):
+        mocked_serializer = mock.MagicMock(spec=Serializer)
+        mocked_serializer.serialize.return_value = "access token request"
+        test_scope = "test"
+
+        fake_response = ApiClientResponse()
+        fake_response.status_code = 400
+        fake_response.body = "test_body"
+
+        fake_api_client = mock.MagicMock(spec=ApiClient)
+        fake_api_client.invoke.return_value = fake_response
+
+        mocked_serializer.deserialize.return_value = "test error body"
+
+        test_lwa_client = LwaClient(
+            api_configuration=ApiConfiguration(
+                serializer=mocked_serializer,
+                api_client=fake_api_client),
+            authentication_configuration=AuthenticationConfiguration())
+
+        with raises(ServiceException) as exc:
+            _actual_token_value = test_lwa_client.get_access_token_for_scope(
+                scope=test_scope)
+
+        assert "Bad Request" in str(exc.value), (
+            "LWA Client get access token threw unknown exception when "
+            "the LWA API call failed with an known exception")
+
+
+    def test_get_access_token_for_null_lwa_response_throw_exception(
+            self):
+        mocked_api_client = MockedApiClient()
+        mocked_serializer = mock.MagicMock(spec=Serializer)
+        test_scope = "test"
+
+        test_lwa_client = LwaClient(
+            api_configuration=ApiConfiguration(
+                serializer=mocked_serializer,
+                api_client=mocked_api_client),
+            authentication_configuration=AuthenticationConfiguration())
+
+        with mock.patch.object(
+                test_lwa_client, "_generate_access_token", return_value=None):
+
+            with raises(ValueError) as exc:
+                test_lwa_client.get_access_token_for_scope(scope=test_scope)
+
+            assert str(exc.value) == "Invalid response from LWA Client " \
+                                     "generate access token call", (
+                "LWA Client get access token call didn't throw exception if a "
+                "generate access token returns None ")

--- a/ask-sdk-model-runtime/tests/unit/test_serialize.py
+++ b/ask-sdk-model-runtime/tests/unit/test_serialize.py
@@ -1,0 +1,556 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights
+# Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+import unittest
+import datetime
+import decimal
+
+from six import text_type
+from mock import patch
+
+from ask_sdk_model_runtime import DefaultSerializer, SerializationException
+
+from . import data
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+try:
+    long_type = long
+except NameError:
+    long_type = int
+
+unicode_type = text_type
+
+
+class TestSerialization(unittest.TestCase):
+    def setUp(self):
+        self.test_serializer = DefaultSerializer()
+
+    def test_none_obj_serialization(self):
+        test_obj = None
+        assert self.test_serializer.serialize(test_obj) is None, \
+            "Default Serializer serialized None object incorrectly"
+
+    def test_primitive_obj_serialization(self):
+        test_obj = "test"
+        assert self.test_serializer.serialize(test_obj) == test_obj, \
+            "Default Serializer serialized str object incorrectly"
+
+        test_obj = 123
+        assert self.test_serializer.serialize(test_obj) == test_obj, \
+            "Default Serializer serialized int object incorrectly"
+
+        test_obj = u"test"
+        assert self.test_serializer.serialize(test_obj) == test_obj, \
+            "Default Serializer serialized unicode object incorrectly"
+
+        test_obj = b"test"
+        assert self.test_serializer.serialize(test_obj) == test_obj, \
+            "Default Serializer serialized bytes object incorrectly"
+
+        test_obj = False
+        assert self.test_serializer.serialize(test_obj) == test_obj, \
+            "Default Serializer serialized bool object incorrectly"
+
+    def test_list_obj_serialization(self):
+        test_obj_inst = data.ModelTestObject2(int_var=123)
+        test_list_obj = ["test", 123, test_obj_inst]
+
+        expected_list = ["test", 123, {"var4Int": 123}]
+        assert self.test_serializer.serialize(test_list_obj) == expected_list, \
+            "Default Serializer serialized list object incorrectly"
+
+    def test_tuple_obj_serialization(self):
+        test_obj_inst = data.ModelTestObject2(int_var=123)
+        test_tuple_obj = ("test", 123, test_obj_inst)
+
+        expected_tuple = ("test", 123, {"var4Int": 123})
+        assert self.test_serializer.serialize(test_tuple_obj) == expected_tuple, \
+            "Default Serializer serialized tuple object incorrectly"
+
+    def test_datetime_obj_serialization(self):
+        test_obj = datetime.datetime(2018, 1, 1, 10, 20, 30)
+        expected_datetime = "2018-01-01T10:20:30"
+        assert self.test_serializer.serialize(test_obj) == expected_datetime, \
+            "Default Serializer serialized datetime object incorrectly"
+
+    def test_date_obj_serialization(self):
+        test_obj = datetime.date(2018, 1, 1)
+        expected_date = "2018-01-01"
+        assert self.test_serializer.serialize(test_obj) == expected_date, \
+            "Default Serializer serialized datetime object incorrectly"
+
+    def test_dict_obj_serialization(self):
+        test_obj_inst = data.ModelTestObject2(int_var=123)
+        test_dict_obj = {
+            "test_str": "test",
+            "test_int": 123,
+            "test_obj": test_obj_inst
+        }
+
+        expected_dict = {
+            "test_str": "test",
+            "test_obj": {
+                "var4Int": 123
+            },
+            "test_int": 123,
+        }
+        assert self.test_serializer.serialize(test_dict_obj) == expected_dict, \
+            "Default Serializer serialized dict object incorrectly"
+
+    def test_model_obj_serialization(self):
+        test_model_obj_2 = data.ModelTestObject2(int_var=123)
+        test_model_obj_1 = data.ModelTestObject1(
+            str_var="test", datetime_var=datetime.datetime(
+                2018, 1, 1, 10, 20, 30), obj_var=test_model_obj_2)
+
+        expected_serialized_obj = {
+            "var1": "test",
+            "var2Time": "2018-01-01T10:20:30",
+            "var3Object": {
+                "var4Int": 123
+            }
+        }
+        assert self.test_serializer.serialize(test_model_obj_1) == expected_serialized_obj, \
+            "Default Serializer serialized model object incorrectly"
+
+    def test_model_obj_without_attrmap_serialization(self):
+        test_obj_inst = data.ModelTestObject3(str_var="test", int_var=123)
+        expected_dict = {
+            "str_var": "test",
+            "int_var": 123
+        }
+        assert self.test_serializer.serialize(test_obj_inst) == expected_dict, \
+            "Default Serializer serialized object without attribute_map incorrectly"
+
+    def test_model_obj_with_incomplete_attrmap_serialization(self):
+        test_obj_inst = data.ModelTestObject4(str_var="test", float_var=3.14)
+        expected_dict = {
+            "str_var": "test",
+            "floatingValue": 3.14
+        }
+        assert self.test_serializer.serialize(test_obj_inst) == expected_dict, \
+            "Default Serializer serialized object with incomplete attribute map incorrectly"
+
+    def test_enum_obj_serialization(self):
+        test_model_obj_2 = data.ModelTestObject2(int_var=123)
+        test_enum_obj = data.ModelEnumObject("ENUM_VAL_1")
+        test_model_obj_1 = data.ModelTestObject1(
+            str_var="test", datetime_var=datetime.datetime(
+                2018, 1, 1, 10, 20, 30), obj_var=test_model_obj_2,
+            enum_var=test_enum_obj)
+
+        expected_serialized_obj = {
+            "var1": "test",
+            "var2Time": "2018-01-01T10:20:30",
+            "var6Enum": "ENUM_VAL_1",
+            "var3Object": {
+                "var4Int": 123
+            }
+        }
+        assert self.test_serializer.serialize(test_model_obj_1) == expected_serialized_obj, \
+            "Default Serializer serialized enum object incorrectly"
+
+    def test_decimal_obj_without_decimals_serialization(self):
+        test_decimal_obj = decimal.Decimal(10)
+        expected_obj = 10
+        actual_obj = self.test_serializer.serialize(test_decimal_obj)
+
+        assert actual_obj == expected_obj, (
+            "Default Serializer serialized decimal object containing no "
+            "decimals incorrectly")
+        assert type(actual_obj) == int, (
+            "Default Serializer serialized decimal object containing no "
+            "decimals to incorrect type")
+
+    def test_decimal_obj_with_decimals_serialization(self):
+        test_decimal_obj = decimal.Decimal(10.5)
+        expected_obj = 10.5
+        actual_obj = self.test_serializer.serialize(test_decimal_obj)
+
+        assert actual_obj == expected_obj, (
+            "Default Serializer serialized decimal object containing "
+            "decimals incorrectly")
+        assert type(actual_obj) == float, (
+            "Default Serializer serialized decimal object containing "
+            "decimals to incorrect type")
+
+
+class TestDeserialization(unittest.TestCase):
+    def setUp(self):
+        self.test_serializer = DefaultSerializer()
+
+    def test_none_obj_deserialization(self):
+        test_payload = None
+        test_obj_type = str
+        assert self.test_serializer.deserialize(
+            test_payload, test_obj_type) is None, \
+            "Default Serializer deserialized None object incorrectly"
+
+    def test_str_obj_deserialization(self):
+        test_payload = "test"
+        test_obj_type = str
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert self.test_serializer.deserialize(
+                test_payload, test_obj_type) == test_payload, \
+                "Default Serializer deserialized string object incorrectly"
+
+    def test_unicode_obj_deserialization(self):
+        test_payload = u"√"
+        test_obj_type = unicode_type
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert self.test_serializer.deserialize(
+                test_payload, test_obj_type) == u"\u221a", \
+                "Default Serializer deserialized unicode string object incorrectly"
+
+    def test_int_obj_deserialization(self):
+        test_payload = 123
+        test_obj_type = int
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert self.test_serializer.deserialize(
+                test_payload, test_obj_type) == test_payload, \
+                "Default Serializer deserialized int object incorrectly"
+
+    def test_long_obj_deserialization(self):
+        test_payload = 123
+        test_obj_type = long_type
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert self.test_serializer.deserialize(
+                test_payload, test_obj_type) == long_type(test_payload), \
+                "Default Serializer deserialized long object incorrectly"
+
+    def test_primitive_obj_deserialization_raising_unicode_exception(self):
+        test_serializer = DefaultSerializer()
+        mocked_primitive_type = mock.Mock(
+            side_effect=UnicodeEncodeError('hitchhiker', u"", 42, 43, 'the universe and everything else'))
+
+        test_serializer.PRIMITIVE_TYPES = [mocked_primitive_type]
+
+        test_payload = u"√"
+        test_obj_type = mocked_primitive_type
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert test_serializer.deserialize(
+                test_payload, test_obj_type) == u"\u221a", \
+                "Default Serializer deserialized primitive type which raises UnicodeEncodeError incorrectly"
+
+    def test_primitive_obj_deserialization_raising_type_error(self):
+        test_serializer = DefaultSerializer()
+        mocked_primitive_type = mock.Mock(side_effect=TypeError())
+
+        test_serializer.PRIMITIVE_TYPES = [mocked_primitive_type]
+
+        test_payload = "test"
+        test_obj_type = mocked_primitive_type
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert test_serializer.deserialize(
+                test_payload, test_obj_type) == test_payload, \
+                "Default Serializer deserialized primitive type which raises TypeError incorrectly"
+
+    def test_primitive_obj_deserialization_raising_value_error(self):
+        test_payload = "test"
+        test_obj_type = int
+
+        with self.assertRaises(SerializationException) as exc:
+            with patch("json.loads") as mock_json_loader:
+                mock_json_loader.return_value = test_payload
+                self.test_serializer.deserialize(test_payload, test_obj_type)
+
+        assert "Failed to parse test into 'int' object" in str(exc.exception), \
+            "Default Serializer didn't throw SerializationException when invalid primitive type is deserialized"
+
+    def test_datetime_obj_serialization(self):
+        # payload in iso8601 format
+        test_payload = "2018-01-01T10:20:30"
+        test_obj_type = datetime.datetime
+
+        expected_obj = datetime.datetime(2018, 1, 1, 10, 20, 30)
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert self.test_serializer.deserialize(test_payload, test_obj_type) == expected_obj, \
+                "Default Serializer deserialized datetime object incorrectly"
+
+    def test_date_obj_serialization(self):
+        # payload in iso8601 format
+        test_payload = "2018-01-01"
+        test_obj_type = datetime.date
+
+        expected_obj = datetime.date(2018, 1, 1)
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert self.test_serializer.deserialize(test_payload, test_obj_type) == expected_obj, \
+                "Default Serializer deserialized date object incorrectly"
+
+    def test_datetime_obj_deserialization_raising_value_error(self):
+        test_payload = "abc-wx-yzT25:80:90"
+        test_obj_type = datetime.datetime
+
+        with self.assertRaises(SerializationException) as exc:
+            with patch("json.loads") as mock_json_loader:
+                mock_json_loader.return_value = test_payload
+                self.test_serializer.deserialize(test_payload, test_obj_type)
+
+        assert "Failed to parse abc-wx-yzT25:80:90 into 'datetime' object" in str(exc.exception), \
+            "Default Serializer didn't throw SerializationException when invalid datetime type is deserialized"
+
+    def test_datetime_obj_deserialization_raising_import_error(self):
+        test_payload = "abc-wx-yzT25:80:90"
+        test_obj_type = datetime.datetime
+
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            with mock.patch('dateutil.parser.parse') as parse_class:
+                parse_class.side_effect = ImportError
+                assert self.test_serializer.deserialize(
+                    test_payload, test_obj_type) == test_payload, \
+                    "Default Serializer didn't return datetime correctly for import errors"
+                parse_class.assert_called_once_with(test_payload)
+
+    def test_obj_type_deserialization(self):
+        test_payload = "test"
+        test_obj_type = object
+
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert self.test_serializer.deserialize(
+                test_payload, test_obj_type) == test_payload, \
+                "Default Serializer deserialization of object returned other than the object itself"
+
+    def test_native_type_mapping_deserialization(self):
+        test_payload = "test"
+        test_obj_type = "str"
+
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert self.test_serializer.deserialize(
+                test_payload, test_obj_type) == test_payload, (
+                "Default Serializer deserialization of object with object_type of string class under native mapping "
+                "not deserialized correctly")
+
+    def test_polymorphic_list_obj_deserialization(self):
+        test_payload = ["test", 123, "2018-01-01T10:20:30"]
+        test_obj_type = "list[str, long, datetime]"
+
+        deserialized_datetime_obj = datetime.datetime(2018, 1, 1, 10, 20, 30)
+        expected_obj = ["test", 123, deserialized_datetime_obj]
+
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert self.test_serializer.deserialize(
+                test_payload, test_obj_type) == expected_obj, (
+                "Default Serializer deserialized list containing poly type object incorrectly")
+
+    def test_similar_list_obj_deserialization(self):
+        test_payload = ["test", "test1", "2018-01-01T10:20:30"]
+        test_obj_type = "list[str]"
+        expected_obj = ["test", "test1", "2018-01-01T10:20:30"]
+
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert self.test_serializer.deserialize(
+                test_payload, test_obj_type) == expected_obj, (
+                "Default Serializer deserialized list object containing similar type objects incorrectly")
+
+    def test_dict_obj_deserialization(self):
+        test_payload = {
+            "test_key": ["test_val_1", "test_val_2"],
+            "test_date_str": ["2018-01-01T10:20:30"]
+        }
+        test_obj_type = "dict(str, list[str])"
+
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert self.test_serializer.deserialize(
+                test_payload, test_obj_type) == test_payload, (
+                "Default Serializer deserialized dict object incorrectly")
+
+    def test_model_obj_deserialization(self):
+        test_payload = {
+            "var1": "test",
+            "var2Time": "2018-01-01T10:20:30",
+            "var3Object": {
+                "var4Int": 123
+            },
+            "var6Enum": "ENUM_VAL_1"
+        }
+        test_obj_type = data.ModelTestObject1
+        expected_datetime_obj = datetime.datetime(2018, 1, 1, 10, 20, 30)
+        expected_sub_obj = data.ModelTestObject2(int_var=123)
+        expected_enum_obj = data.ModelEnumObject("ENUM_VAL_1")
+        expected_obj = data.ModelTestObject1(
+            str_var="test", datetime_var=expected_datetime_obj, obj_var=expected_sub_obj, enum_var=expected_enum_obj)
+
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert self.test_serializer.deserialize(
+                test_payload, test_obj_type) == expected_obj, (
+                "Default Serializer deserialized model object incorrectly")
+
+    def test_model_obj_with_additional_params_in_payload_deserialization(self):
+        test_payload = {
+            "var4Int": 123,
+            "add_param_1": "Test"
+        }
+        test_obj_type = data.ModelTestObject2
+        expected_obj = data.ModelTestObject2(int_var=123)
+        expected_obj.add_param_1 = "Test"
+
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert self.test_serializer.deserialize(
+                test_payload, test_obj_type) == expected_obj, (
+                "Default Serializer deserialized model object incorrectly when payload has additional parameters")
+
+    def test_model_obj_without_attrmap_deserialization(self):
+        test_payload = {
+            "str_var": "Test",
+            "int_var": 123
+        }
+        test_obj_type = data.ModelTestObject3
+        expected_obj = data.ModelTestObject3(str_var="Test", int_var=123)
+
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert self.test_serializer.deserialize(
+                test_payload, test_obj_type) == expected_obj, (
+                "Default Serializer deserialized model object without attribute map incorrectly")
+
+    def test_model_obj_with_incomplete_attrmap_deserialization(self):
+        test_payload = {
+            "str_var": "Test",
+            "floatingValue": 3.14
+        }
+        test_obj_type = data.ModelTestObject4
+        expected_obj = data.ModelTestObject4(str_var="Test", float_var=3.14)
+
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert self.test_serializer.deserialize(
+                test_payload, test_obj_type) == expected_obj, (
+                "Default Serializer deserialized model object with incomplete attribute map incorrectly")
+
+    def test_invalid_model_obj_deserialization(self):
+        test_payload = {
+            "var_1": "some value"
+        }
+        test_obj_type = data.InvalidModelObject
+
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert self.test_serializer.deserialize(
+                test_payload, test_obj_type) == test_payload, (
+                "Default Serializer didn't provide payload back when an invalid model object type "
+                "(without attribute map and swagger type dict) is passed")
+
+    def test_invalid_model_obj_type_deserialization(self):
+        test_payload = {
+            "var_1": "some value"
+        }
+        test_obj_type = "InvalidModelObject"
+
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            with self.assertRaises(SerializationException) as exc:
+                self.test_serializer.deserialize(test_payload, test_obj_type)
+
+            assert "Unable to resolve class {} from installed modules".format(test_obj_type) in str(exc.exception), (
+                "Default Serializer didn't throw SerializationException when deserialization is called with invalid "
+                "object type")
+
+    def test_invalid_json_deserialization(self):
+        test_payload = {
+            "var_1": "some value"
+        }
+        test_obj_type = "str"
+
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.side_effect = Exception
+            with self.assertRaises(SerializationException) as exc:
+                self.test_serializer.deserialize(test_payload, test_obj_type)
+
+        assert "Couldn't parse response body" in str(exc.exception), \
+            "Default Serializer didn't throw SerializationException when invalid json is deserialized"
+
+    def test_parent_model_obj_with_discriminator_deserialization(self):
+        test_payload = {
+            "ChildType": 'ChildType1',
+            "var1": "Some string",
+            "var3Object": {
+                "var4Int": 123
+            },
+            "testVar": "test string"
+        }
+        test_obj_type = data.ModelAbstractParentObject
+        expected_sub_obj = data.ModelTestObject2(int_var=123)
+        expected_obj = data.ModelChildObject1(
+            str_var="Some string", obj_var=expected_sub_obj, test_var="test string")
+
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert self.test_serializer.deserialize(
+                test_payload, test_obj_type) == expected_obj, (
+                "Default Serializer deserialized model object incorrectly when object type is parent class "
+                "with discriminator")
+
+    def test_child_discriminator_model_obj_deserialization(self):
+        test_payload = {
+            "ChildType": 'ChildType2',
+            "var1": "Some string",
+            "var3Object": {
+                "var4Int": 123
+            },
+            "testIntVar": 456
+        }
+        test_obj_type = data.ModelChildObject2
+        expected_sub_obj = data.ModelTestObject2(int_var=123)
+        expected_obj = data.ModelChildObject2(
+            str_var="Some string", obj_var=expected_sub_obj, test_int_var=456)
+
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            assert self.test_serializer.deserialize(
+                test_payload, test_obj_type) == expected_obj, (
+                "Default Serializer deserialized model object incorrectly when object type is parent class "
+                "with discriminator")
+
+    def test_parent_model_obj_with_invalid_discriminator_deserialization(self):
+        test_payload = {
+            "ChildType": 'InvalidType',
+            "var1": "Some string",
+            "var3Object": {
+                "var4Int": 123
+            },
+            "testVar": "test string"
+        }
+        test_obj_type = data.ModelAbstractParentObject
+
+        with patch("json.loads") as mock_json_loader:
+            mock_json_loader.return_value = test_payload
+            with self.assertRaises(SerializationException) as exc:
+                self.test_serializer.deserialize(test_payload, test_obj_type)
+
+            assert "Couldn't resolve object by discriminator type" in str(exc.exception), (
+                "Default Serializer didn't throw SerializationException when deserialization is called with invalid "
+                "discriminator type in payload and parent model")


### PR DESCRIPTION
<!--
Since these model classes are auto-generated using the [JSON schemas](https://developer.amazon.com/docs/custom-skills/request-and-response-json-reference.html) 
in the developer documentation, we do not currently accept Pull Requests.

All Pull Requests will be automatically closed, unless the request is generic and applies across **ALL** model classes.
!-->
## Description
<!--- Describe your changes in detail -->

- Created an ask-sdk-model-runtime package which contains the defintions of LWA servies, implementations of ApiClient and its componenets, also default Serializer definitions.
- This package can be reused across multiple models released by ask sdk team in future, also the current ask-sdk-models (python) can add this as dependency.

## Testing
ask-sdk-model-runtime package has unit test cases attached for all the components defined.


## Checklist
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] The change is generic and can be done across all model classes.
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
