### PR TITLE
fix wrong interaction_model Prompts import

### DIFF
--- a/ask-smapi-model/ask_smapi_model/v1/skill/interaction_model/dialog_intents.py
+++ b/ask-smapi-model/ask_smapi_model/v1/skill/interaction_model/dialog_intents.py
@@ -25,7 +25,7 @@ if typing.TYPE_CHECKING:
     from datetime import datetime
     from ask_smapi_model.v1.skill.interaction_model.dialog_slot_items import DialogSlotItems
     from ask_smapi_model.v1.skill.interaction_model.delegation_strategy_type import DelegationStrategyType
-    from ask_smapi_model.v1.skill.interaction_model.prompts import Prompts
+    from ask_smapi_model.v1.skill.interaction_model import Prompts
 
 
 class DialogIntents(object):
@@ -40,7 +40,7 @@ class DialogIntents(object):
     :param confirmation_required: Describes whether confirmation of the intent is required.
     :type confirmation_required: (optional) bool
     :param prompts: 
-    :type prompts: (optional) ask_smapi_model.v1.skill.interaction_model.prompts.Prompts
+    :type prompts: (optional) ask_smapi_model.v1.skill.interaction_model.Prompts
 
     """
     deserialized_types = {
@@ -48,7 +48,7 @@ class DialogIntents(object):
         'delegation_strategy': 'ask_smapi_model.v1.skill.interaction_model.delegation_strategy_type.DelegationStrategyType',
         'slots': 'list[ask_smapi_model.v1.skill.interaction_model.dialog_slot_items.DialogSlotItems]',
         'confirmation_required': 'bool',
-        'prompts': 'ask_smapi_model.v1.skill.interaction_model.prompts.Prompts'
+        'prompts': 'ask_smapi_model.v1.skill.interaction_model.Prompts'
     }  # type: Dict
 
     attribute_map = {
@@ -73,7 +73,7 @@ class DialogIntents(object):
         :param confirmation_required: Describes whether confirmation of the intent is required.
         :type confirmation_required: (optional) bool
         :param prompts: 
-        :type prompts: (optional) ask_smapi_model.v1.skill.interaction_model.prompts.Prompts
+        :type prompts: (optional) ask_smapi_model.v1.skill.interaction_model.Prompts
         """
         self.__discriminator_value = None  # type: str
 


### PR DESCRIPTION
<!--
Since these model classes are auto-generated using the [JSON schemas](https://developer.amazon.com/docs/custom-skills/request-and-response-json-reference.html) 
in the developer documentation, we do not currently accept Pull Requests.

All Pull Requests will be automatically closed, unless the request is generic and applies across **ALL** model classes.
!-->
## Description
<!--- Describe your changes in detail -->

Changed the `Prompts` import 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment like python version, dependencies,  -->
<!--- and the tests you ran to see how your change affects other areas of the code, etc. -->
Python Environment: `3.6.5`

Manually tested methods that give me the error (like the one below) and now they are working.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

Using some SMAPI calls (like `get_interaction_model_v1` or other requests that involve interaction model) it returns this error:

```Unable to resolve class ask_smapi_model.v1.skill.interaction_model.prompts.Prompts from installed modules: No module named 'ask_smapi_model.v1.skill.interaction_model.prompts'```

So I change the import with the correct `Prompts` 

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] The change is generic and can be done across all model classes.
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
